### PR TITLE
Change pyplot extentions to plot using matplotlib inline

### DIFF
--- a/RCMRD_Demo/Demo_Crop_Growth.ipynb
+++ b/RCMRD_Demo/Demo_Crop_Growth.ipynb
@@ -44,7 +44,7 @@
     }
    ],
    "source": [
-    "%pylab notebook\n",
+    "%matplotlib inline\n",
     "\n",
     "from matplotlib import pyplot as plt\n",
     "import xarray as xr\n",


### PR DESCRIPTION
Code changes:
Since the Sandbox is now default to Lab `pyplot` is not supported for JupyterLab 
Change `%pyplot notebook% to plot the images using `%matplotlib inline` 
Note that this can also be used with notebook and Lab.
In order to have an interactive inline we need to set the `%matplotlib inline` to `%matplotlib widget`
