### PR TITLE
Close #54 by calculating aspect using `odc.ui` tools

### DIFF
--- a/Scripts/deafrica_plotting.py
+++ b/Scripts/deafrica_plotting.py
@@ -25,31 +25,32 @@ Functions included:
     animated_timeseriesline
     animated_doubletimeseries
 
-Last modified: October 2019
+Last modified: March 2020
 
 '''
 
 # Import required packages
+import calendar
 import folium  
 import math
 import numpy as np
 import ipywidgets
+import geopandas as gpd
 import matplotlib as mpl
-from pyproj import Proj, transform
-from IPython.display import display
-from ipyleaflet import Map, Marker, Popup, GeoJSON, basemaps, Choropleth
-from skimage import exposure
 import matplotlib.patheffects as PathEffects
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
-from branca.colormap import linear
-
 from datetime import datetime
-import calendar
+from pyproj import Proj, transform
+from IPython.display import display
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
-import geopandas as gpd
-from matplotlib.colors import ListedColormap
 from mpl_toolkits.axes_grid1 import make_axes_locatable
+from matplotlib.colors import ListedColormap
+from ipyleaflet import Map, Marker, Popup, GeoJSON, basemaps, Choropleth
+from skimage import exposure
+from branca.colormap import linear
+from odc.ui import image_aspect
+
 
 def rgb(ds,
         bands=['red', 'green', 'blue'],
@@ -145,11 +146,9 @@ def rgb(ds,
         # Create empty aspect size kwarg that will be passed to imshow
         aspect_size_kwarg = {}    
     else:
-        # Compute image aspect based on the last two dimensions (this will 
-        # exclude the index dim if it is present in the dataset)
+        # Compute image aspect 
         if not aspect:
-            x_dim, y_dim = list(ds.dims)[-2:]
-            aspect = len(ds[x_dim]) / len(ds[y_dim])
+            aspect = image_aspect(ds)
         
         # Populate aspect size kwarg with aspect and size data
         aspect_size_kwarg = {'aspect': aspect, 'size': size}


### PR DESCRIPTION
### Proposed changes
Issue #54 was caused by DEAfrica S1 data loading with an unexpected dimension order, which caused time to be used instead of longitude when calculating the image aspect in `rgb`.

Have replaced the existing code with `from odc.ui import image_aspect` which is more resilient to dimension order.

### Closes issues (optional)
- Closes Issue #54