### PR TITLE
Update Rasterize and Vectorize notebook

### DIFF
--- a/Frequently_used_code/Rasterize_vectorize.ipynb
+++ b/Frequently_used_code/Rasterize_vectorize.ipynb
@@ -25,12 +25,14 @@
    "metadata": {},
    "source": [
     "## Description\n",
-    "This notebook demonstrates the use of the DE Africa function `xr_rasterize` and `xr_vectorize` in [deafrica_spatialtools.py](../Scripts/deafrica_spatialtools.py).  \n",
+    "In this notebook, we show how to use the Digital Earth Africa function `xr_rasterize` and `xr_vectorize` in [deafrica_spatialtools.py](../Scripts/deafrica_spatialtools.py). The notebook demonstrates how to:\n",
     "\n",
-    "The first section loads in [Water Observations from Space (WOfS)](https://maps.digitalearth.africa/#share=s-jENTWtaN98vMumZGcwM2iZXzFBo) data from Digital Earth Africa, and vectorises the pixel-based `xarray.DataArray` object into a vector-based `geopandas.GeoDataFrame` object containing persistent water-bodies as polygons. \n",
-    "We then export the `GeoDataframe` as a shapefile.  \n",
+    "1. Load in data from the [Water Observations from Space (WOfS)](https://maps.digitalearth.africa/#share=s-jENTWtaN98vMumZGcwM2iZXzFBo) product\n",
+    "2. Vectorise the pixel-based `xarray.DataArray` WOfS object into a vector-based `geopandas.GeoDataFrame` object containing persistent water-bodies as polygons\n",
+    "3. Export the `geopandas.GeoDataFrame` as a shapefile\n",
+    "4. Rasterize the `geopandas.GeoDataFrame` vector data back into an `xarray.DataArray` object and export the results as a GeoTIFF\n",
     "\n",
-    "The second section rasterises the vector data we created in the first section back into an `xarray.DataArray`, and exports the results as a GeoTIFF."
+    "***"
    ]
   },
   {

--- a/Frequently_used_code/Rasterize_vectorize.ipynb
+++ b/Frequently_used_code/Rasterize_vectorize.ipynb
@@ -380,7 +380,7 @@
     "**Contact:** If you need assistance, please post a question on the [Open Data Cube Slack channel](http://slack.opendatacube.org/) or on the [GIS Stack Exchange](https://gis.stackexchange.com/questions/ask?tags=open-data-cube) using the `open-data-cube` tag (you can view previously asked questions [here](https://gis.stackexchange.com/questions/tagged/open-data-cube)).\n",
     "If you would like to report an issue with this notebook, you can file one on [Github](https://github.com/digitalearthafrica/deafrica-sandbox-notebooks).\n",
     "\n",
-    "**Last modified:** January 2019\n",
+    "**Last modified:** May 2020\n",
     "\n",
     "**Compatible datacube version:** "
    ]

--- a/Frequently_used_code/Rasterize_vectorize.ipynb
+++ b/Frequently_used_code/Rasterize_vectorize.ipynb
@@ -196,7 +196,7 @@
     "In the cell below, we use the argument `mask=water_bodies.values==1` to indicate we only want to convert the values in the xarray object that are equal to 1.\n",
     "\n",
     "\n",
-    "> Note: Both `xr_rasterize` and `xr_vectorize` will attempt to automatically obtain the `crs` and `transform` from the input data, but if the data does not contain this information, you will need to manually provide this.  In the cell below, we will get the `crs` and `transform` from the original dataset."
+    "> **Note**: Both `xr_rasterize` and `xr_vectorize` will attempt to automatically obtain the `crs` and `transform` from the input data, but if the data does not contain this information, you will need to manually provide this.  In the cell below, we will get the `crs` and `transform` from the original dataset."
    ]
   },
   {

--- a/Frequently_used_code/Rasterize_vectorize.ipynb
+++ b/Frequently_used_code/Rasterize_vectorize.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "source": [
     "## Description\n",
-    "This notebook demonstrates the use of the DE Africa function `xr_rasterize` and `xr_vectorize` in [Scripts/deafrica_spatialtools.py](../Scripts/deafrica_spatialtools.py).  \n",
+    "This notebook demonstrates the use of the DE Africa function `xr_rasterize` and `xr_vectorize` in [deafrica_spatialtools.py](../Scripts/deafrica_spatialtools.py).  \n",
     "\n",
     "The first section loads in [Water Observations from Space (WOfS)](https://maps.digitalearth.africa/#share=s-jENTWtaN98vMumZGcwM2iZXzFBo) data from Digital Earth Africa, and vectorises the pixel-based `xarray.DataArray` object into a vector-based `geopandas.GeoDataFrame` object containing persistent water-bodies as polygons. \n",
     "We then export the `GeoDataframe` as a shapefile.  \n",
@@ -189,7 +189,7 @@
    "source": [
     "## Vectorizing an `xarray.DataArray`\n",
     "\n",
-    "To convert our `xarray.DataArray` object into a vector based `geopandas geodataframe`, we can use the DE Africa function `xr_vectorize` in the script [Scripts/deafrica_spatialtools.py](../Scripts/deafrica_spatialtools.py). This tool is based on the [rasterio.features.shape](https://rasterio.readthedocs.io/en/stable/api/rasterio.features.html) function, and can accept any of the arguments in `rasterio.features.shape` using the same syntax.\n",
+    "To convert our `xarray.DataArray` object into a vector based `geopandas geodataframe`, we can use the DE Africa function `xr_vectorize` in the script [deafrica_spatialtools.py](../Scripts/deafrica_spatialtools.py). This tool is based on the [rasterio.features.shape](https://rasterio.readthedocs.io/en/stable/api/rasterio.features.html) function, and can accept any of the arguments in `rasterio.features.shape` using the same syntax.\n",
     "\n",
     "In the cell below, we use the argument `mask=water_bodies.values==1` to indicate we only want to convert the values in the xarray object that are equal to 1.\n",
     "\n",
@@ -291,7 +291,7 @@
    "source": [
     "## Rasterizing a shapefile\n",
     "\n",
-    "Using the `xr_rasterize` function in [Scripts/deafrica_spatialtools.py](../Scripts/deafrica_spatialtools.py) (based on the rasterio function: [rasterio.features.rasterize](https://rasterio.readthedocs.io/en/stable/api/rasterio.features.html), and can accept any of the arguments in `rasterio.features.rasterize` using the same syntax) we can turn the `geopandas.GeoDataFrame` back into a `xarray.DataArray`. \n",
+    "Using the `xr_rasterize` function in [deafrica_spatialtools.py](../Scripts/deafrica_spatialtools.py) (based on the rasterio function: [rasterio.features.rasterize](https://rasterio.readthedocs.io/en/stable/api/rasterio.features.html), and can accept any of the arguments in `rasterio.features.rasterize` using the same syntax) we can turn the `geopandas.GeoDataFrame` back into a `xarray.DataArray`. \n",
     "\n",
     "As we already have the `GeoDataFrame` loaded we don't need to read in the shapefile, but if we wanted to read in a shapefile first we can use [gpd.read_file()](http://geopandas.org/reference/geopandas.read_file.html).   \n",
     "\n",
@@ -434,7 +434,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.9"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
### Proposed changes
Updated minor issues with notebook. Includes removal of "scripts" folder reference from links to deafrica_spatialtools.py. Description section was converted from paragraph of text to list of dot points for clarity and consistency. Updated Note to **Note** to conform to other notebooks.

### Checklist (replace `[ ]` with `[x]` to check off)
- [ ] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell and re-use tags if possible
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
