### PR TITLE
Import masking from new location

### DIFF
--- a/Scripts/deafrica_datahandling.py
+++ b/Scripts/deafrica_datahandling.py
@@ -46,7 +46,7 @@ import datetime
 import pytz
 
 from collections import Counter
-from datacube.storage import masking
+from datacube.utils import masking
 from scipy.ndimage import binary_dilation
 from copy import deepcopy
 import odc.algo


### PR DESCRIPTION
### Proposed changes
The masking module has moved. Updating it to avoid the warning:
```
/env/lib/python3.6/site-packages/datacube/storage/masking.py:4: DeprecationWarning: datacube.storage.masking has moved to datacube.utils.masking
  category=DeprecationWarning)
```

### Checklist (replace `[ ]` with `[x]` to check off)
- [X] Remove any unused Python packages from `Load packages`
- [X] Remove any unused/empty code cells
- [X] Remove any guidance cells (e.g. `General advice`)
- [X] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [X] Include relevant tags in the final notebook cell and re-use tags if possible
- [X] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
