### PR TITLE
Random point sampling on xarray dataarrays

### DIFF
--- a/Scripts/deafrica_spatialtools.py
+++ b/Scripts/deafrica_spatialtools.py
@@ -822,7 +822,7 @@ def random_sampling(da,
     if sampling == 'stratified_random':
         #determine class ratios in image
         class_ratio = pd.DataFrame({'proportion': df['class'].value_counts(normalize=True),
-                            'class':pd.unique(df['class'])
+                            'class':df['class'].dropna().unique()
                                  })
         
         for _class in class_ratio['class']:
@@ -834,7 +834,7 @@ def random_sampling(da,
             samples.append(sample_loc)
 
     if sampling == 'equal_stratified_random':
-        classes = pd.unique(df['class'])
+        classes = df['class'].dropna().unique()
         
         for _class in classes:
             #use relative proportions of classes to sample df
@@ -853,13 +853,13 @@ def random_sampling(da,
         no_of_points = n
         #random sample entire df
         print('Randomly sampling dataAraay at '+ str(round(no_of_points)) + ' coordinates')
-        sample_loc = df.sample(n=int(round(no_of_points)))
+        sample_loc = df.dropna().sample(n=int(round(no_of_points)))
         samples.append(sample_loc)
     
     if sampling == 'manual':
         if isinstance(manual_class_ratios, dict):
             #check classes in dict match classes in data
-            classes = pd.unique(df['class'])
+            classes = df['class'].dropna().unique()
             dict_classes = list(manual_class_ratios.keys())
             
             if set(dict_classes).issubset([str(i) for i in classes]):
@@ -907,3 +907,5 @@ def random_sampling(da,
     
     if out_fname is not None:
         gdf.to_file(out_fname)
+    
+    return gdf

--- a/Scripts/deafrica_spatialtools.py
+++ b/Scripts/deafrica_spatialtools.py
@@ -827,7 +827,7 @@ def random_sampling(da,
         
         for _class in class_ratio['class']:
             #use relative proportions of classes to sample df
-            no_of_points = total_points * class_ratio[class_ratio['class']==_class]['proportion'].values[0]
+            no_of_points = n * class_ratio[class_ratio['class']==_class]['proportion'].values[0]
             #random sample each class
             print('Class '+ str(_class)+ ': sampling at '+ str(round(no_of_points)) + ' coordinates')
             sample_loc = df[df['class'] == _class].sample(n=int(round(no_of_points)))
@@ -838,7 +838,7 @@ def random_sampling(da,
         
         for _class in classes:
             #use relative proportions of classes to sample df
-            no_of_points = total_points / len(classes)
+            no_of_points = n / len(classes)
             #random sample each classes
             try:
                 sample_loc = df[df['class'] == _class].sample(n=int(round(no_of_points)))
@@ -850,7 +850,7 @@ def random_sampling(da,
                         pass
     
     if sampling == 'random':
-        no_of_points = total_points
+        no_of_points = n
         #random sample entire df
         print('Randomly sampling dataAraay at '+ str(round(no_of_points)) + ' coordinates')
         sample_loc = df.sample(n=int(round(no_of_points)))

--- a/Scripts/deafrica_spatialtools.py
+++ b/Scripts/deafrica_spatialtools.py
@@ -813,6 +813,7 @@ def random_sampling(da,
                              "'equal_stratified_random', 'random', or 'manual'") 
     
     #open the dataset as a pandas dataframe
+    da = da.squeeze()
     df = da.to_dataframe(name='class')
     
     #list to store points


### PR DESCRIPTION
### Proposed changes
A new function that will generate randomly sampled points to assist in post-classification accuracy assessment.  The options in this function mimic those found in ArcGIS's `Create Accuracy Assessment Points` and R's `spsample`, but will work on xarray objects.

To test this function, supply a classified 2D `xarray.DataArray`, and pick one of the methods listed in the doc strings.

e.g. For stratified random sampling:


```
gdf = random_sampling(da=da,
                    n=500,
                    sampling='stratified_random',
                       )
```

To manually enter the number of points per class (this can be a subset of the classes if you wish):
```
gdf = random_sampling(da=da,
                    n=500, #this is ignored if sampling = 'manual'
                    sampling='manual',
                    manual_class_ratios={'0.0': 200, '1.0':150}
                       )
```