### PR TITLE
Fix typo in readme

### DIFF
--- a/Beginners_guide/README.md
+++ b/Beginners_guide/README.md
@@ -1,6 +1,6 @@
 # Beginner’s Guide 
 
-The notebooks in this folder are designed for new users of Digital Erath Africa and Open Data Cube to provide an introduction to working in Jupyter Notebooks, loading products and plotting images. These notebooks have been modified from the Beginner’s Guide notebooks on the Digital Earth Australia [GitHub Notebook repository](https://github.com/GeoscienceAustralia/dea-notebooks/tree/master)
+The notebooks in this folder are designed for new users of Digital Earth Africa and Open Data Cube to provide an introduction to working in Jupyter Notebooks, loading products and plotting images. These notebooks have been modified from the Beginner’s Guide notebooks on the Digital Earth Australia [GitHub Notebook repository](https://github.com/GeoscienceAustralia/dea-notebooks/tree/master)
 
 ### The following notebooks are designed to be worked through in the following order:
 1.	Jupyter Notebooks


### PR DESCRIPTION
Reported here https://github.com/GeoscienceAustralia/dea-sandbox/issues/89

### Proposed changes
fix minor typo

### Checklist (replace `[ ]` with `[x]` to check off)
- [ ] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell and re-use tags if possible
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
