### PR TITLE
Compute before plotting

### DIFF
--- a/Scripts/deafrica_plotting.py
+++ b/Scripts/deafrica_plotting.py
@@ -195,7 +195,7 @@ def rgb(ds,
                 'the arguments e.g. `col="time", col_wrap=4` to the function ' 
                 'call'
             )
-
+        da = da.compute()
         img = da.plot.imshow(robust=robust,
                              col_wrap=col_wrap,
                              **aspect_size_kwarg,
@@ -224,7 +224,7 @@ def rgb(ds,
         index = index if isinstance(index, list) else [index]
 
         # Select bands and observations and convert to DataArray
-        da = ds[bands].isel(**{index_dim: index}).to_array()
+        da = ds[bands].isel(**{index_dim: index}).to_array().compute()
 
         # If percentile_stretch == True, clip plotting to percentile vmin, vmax
         if percentile_stretch:


### PR DESCRIPTION
### Proposed changes
Computes dask arrays before plotting to prevent multiple evaluations within function

### Closes issues (optional)
- Closes Issue #141 

### Checklist (replace `[ ]` with `[x]` to check off)
- [ ] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell and re-use tags if possible
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
