### PR TITLE
Change from using C2 to C1 data

### DIFF
--- a/Real_world_examples/Coastal_erosion.ipynb
+++ b/Real_world_examples/Coastal_erosion.ipynb
@@ -420,7 +420,7 @@
    "source": [
     "# Calculate the water index\n",
     "landsat_ds = calculate_indices(landsat_ds, index='MNDWI', \n",
-    "                               collection='c2')\n",
+    "                               collection='c1')\n",
     "\n",
     "# Plot the resulting image for the same timestep selected above\n",
     "landsat_ds.MNDWI.isel(time=timestep).plot(cmap='RdBu',\n",


### PR DESCRIPTION
### Proposed changes
The coastal erosion notebook had a setting to use collection 2 data, which is not available in the public sandbox. This change fixes this to use collection 1 data.

