### PR TITLE
Add more informative error messages to mostcommon_crs

### DIFF
--- a/Scripts/deafrica_datahandling.py
+++ b/Scripts/deafrica_datahandling.py
@@ -21,7 +21,7 @@ Functions included:
     load_ard
     load_masked_FC
     array_to_geotiff
-    mostcommon_utm
+    mostcommon_crs
     download_unzip
     wofs_fuser
     dilate
@@ -29,7 +29,7 @@ Functions included:
     last
     nearest
 
-Last modified: March 2020
+Last modified: Jan 2021
 
 '''
 
@@ -624,25 +624,38 @@ def mostcommon_crs(dc, product, query):
     if 'align' in query:
         query.pop('align', None)
     
-    # List of matching products    
+    # List of matching products
     matching_datasets = dc.find_datasets(product=product, **query)
-    
+
     # Extract all CRSs
-    crs_list = [str(i.crs) for i in matching_datasets]    
-   
-    # Identify most common CRS
-    crs_counts = Counter(crs_list)
-    crs_mostcommon = crs_counts.most_common(1)[0][0]
-
-    # Warn user if multiple CRSs are encountered
-    if len(crs_counts.keys()) > 1:
-
-        warnings.warn(f'Multiple UTM zones {list(crs_counts.keys())} '
-                      f'were returned for this query. Defaulting to '
-                      f'the most common zone: {crs_mostcommon}', 
-                      UserWarning)
+    crs_list = [str(i.crs) for i in matching_datasets]
     
-    return crs_mostcommon
+    # If CRSs are returned
+    if len(crs_list) > 0:
+
+        # Identify most common CRS
+        crs_counts = Counter(crs_list)
+        crs_mostcommon = crs_counts.most_common(1)[0][0]
+
+        # Warn user if multiple CRSs are encountered
+        if len(crs_counts.keys()) > 1:
+
+            warnings.warn(f'Multiple UTM zones {list(crs_counts.keys())} '
+                          f'were returned for this query. Defaulting to '
+                          f'the most common zone: {crs_mostcommon}',
+                          UserWarning)
+
+        return crs_mostcommon
+    
+    else:
+        
+        raise ValueError(f'No CRS was returned as no data was found for '
+                         f'the supplied product ({product}) and query. '
+                         f'Please ensure that data is available for '
+                         f'{product} for the spatial extents and time '
+                         f'period specified in the query (e.g. by using '
+                         f'the Data Cube Explorer for this datacube '
+                         f'instance).')
 
 
 def download_unzip(url,


### PR DESCRIPTION
### Proposed changes
This PR ports across recent changes to the `mostcommon_crs` function in `dea-notebooks` which added a more informative error message when the function is run for a location with no available data:

https://github.com/GeoscienceAustralia/dea-notebooks/pull/751
