### PR TITLE
update geopanda dependency

### DIFF
--- a/Tools/setup.py
+++ b/Tools/setup.py
@@ -10,7 +10,7 @@ package_data = \
 install_requires = \
 ['dask-ml>=1.8.0,<2.0.0',
  'datacube>=1.8.3,<2.0.0',
- 'geopandas>=0.8.2,<0.9.0',
+ 'geopandas>=0.8.2,<=0.9.0',
  'joblib>=1.0.1,<2.0.0',
  'matplotlib>=3.3.4,<4.0.0',
  'scikit-learn>=0.24.1,<0.25.0',


### PR DESCRIPTION
### Proposed changes
Include a brief description of the changes being proposed, and why they are necessary.

Make sure `deafrica-tools` installing `geopandas == 0.9.0` as part of `dea-sandbox` image upgrade


### Closes issues (optional)
- Closes Issue #000
- Closes Issue #000

### Checklist (replace `[ ]` with `[x]` to check off)
- [ ] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell and re-use tags if possible
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
