### PR TITLE
improve and simplify the water extent nb

### DIFF
--- a/Real_world_examples/Water_extent.ipynb
+++ b/Real_world_examples/Water_extent.ipynb
@@ -135,40 +135,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table style=\"border: 2px solid white;\">\n",
-       "<tr>\n",
-       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
-       "<h3 style=\"text-align: left;\">Client</h3>\n",
-       "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Scheduler: </b>tcp://127.0.0.1:35325</li>\n",
-       "  <li><b>Dashboard: </b><a href='/user/eefaye.chong/proxy/8787/status' target='_blank'>/user/eefaye.chong/proxy/8787/status</a></li>\n",
-       "</ul>\n",
-       "</td>\n",
-       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
-       "<h3 style=\"text-align: left;\">Cluster</h3>\n",
-       "<ul style=\"text-align: left; list-style:none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Workers: </b>1</li>\n",
-       "  <li><b>Cores: </b>2</li>\n",
-       "  <li><b>Memory: </b>13.11 GB</li>\n",
-       "</ul>\n",
-       "</td>\n",
-       "</tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Client: 'tcp://127.0.0.1:35325' processes=1 threads=2, memory=13.11 GB>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "create_local_dask_cluster()"
    ]


### PR DESCRIPTION
### Proposed changes
The `water_extent` notebook in `Real_world_examples` was failing.  On inspection the notebook was unwieldy and gave unreliable results. I have substantially simplified and improved the notebook, bringing it into line with recent related notebooks produced for other use-cases.

A few notable changes:
- it no longer uses WOfS, but instead uses MNDWI calculated from S2
- Relying on _seasonal_ medians to ensure the entire waterbody is captured at each time-period (monthly is too frequent)
- Shifted the default analysis area to a smaller and more variable water-body, now it runs much faster and the results are more distinctive
- The animation is just for MNDWI - the RGB animation has been removed as this doesn't add any more insight and requires loading twice as much satellite data
- The final 'change' plot was tidied and the colours were changed to make it easier on the eye