### PR TITLE
Fix Landsat SLC-off bug

### DIFF
--- a/Tools/deafrica_tools/datahandling.py
+++ b/Tools/deafrica_tools/datahandling.py
@@ -422,7 +422,7 @@ def load_ard(
             datasets = dc.find_datasets(product=product, **query)
 
         # Remove Landsat 7 SLC-off observations if ls7_slc_off=False
-        if not ls7_slc_off and product in ["ls7_c2l2"]:
+        if not ls7_slc_off and product in ["ls7_sr"]:
             if verbose:
                 print("    Ignoring SLC-off observations for ls7")
             datasets = [


### PR DESCRIPTION
### Proposed changes
The `deafrica_tools.load_ard` func currently has a bug where setting `ls7_slc_off=False` or `ls7_slc_off=True` has no effect. This is because an older product name was used instead of `ls7_sr`.

