### PR TITLE
Update overlay layers to include ESRI basemap

### DIFF
--- a/Real_world_examples/Wetlands_insight_tool.ipynb
+++ b/Real_world_examples/Wetlands_insight_tool.ipynb
@@ -106,7 +106,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7f2ad0ef92b0416d8ab6507aaa06b5bf",
+       "model_id": "70c24efc7a1e4a0b96bce7212e9b3580",
        "version_major": 2,
        "version_minor": 0
       },

--- a/Real_world_examples/Wetlands_insight_tool.ipynb
+++ b/Real_world_examples/Wetlands_insight_tool.ipynb
@@ -81,7 +81,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* `DE Africa Overlay`: An optional DE Africa product to overlay on the basemaps, this can help guide the drawing of a polygon. Options include the 2020 Sentinel-2 Geomedian, or the 2020 WOfS annual frequency summary. This parameter defaults to 'None' in which case Esri's World Imagery provides a high-resolution basemap.\n",
+    "* `Map Overlay`: A number of overlay map layers, which can help guide polygon drawing. Options include ESRI World Imagery, the 2020 Sentinel-2 Geomedian, or the 2020 WOfS annual frequency summary. This parameter defaults to 'None'.\n",
     "* `Start Date`: The starting date of the analysis, in format DD-MM-YYYY\n",
     "* `End Date`: The ending date of the analysis, in format DD-MM-YYYY\n",
     "* `Minimum Good Data`: A number between 0 and 1 (e.g. `0.85`) indicating the minimum percentage of good quality pixels required for a satellite observation to be loaded and therefore included in the WIT plot. **This number should, at a minimum, be set to 0.85 to limit biases in the result if not resampling the time-series**. If resampling the data using the parameter `Resample Frequency`, then setting this number to 0 (or a low float number) is acceptable.\n",
@@ -106,7 +106,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ed8e36d025b84d81ad9df30c90da8eac",
+       "model_id": "7f2ad0ef92b0416d8ab6507aaa06b5bf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -178,7 +178,7 @@
     {
      "data": {
       "text/plain": [
-       "'2021-10-15'"
+       "'2021-11-03'"
       ]
      },
      "execution_count": 3,
@@ -209,6 +209,832 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.10"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "012ab6ad3ce7485a880980de064ef95a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "05183ed950e844bebe30287ddbe8cc77": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_77b218dd1f9248cd8d3426822b3e0d3c",
+       "style": "IPY_MODEL_cc9ec68f70934c7986927411be9be1de",
+       "value": "<h3>Wetlands Insight Tool</h3><p>Select parameters and AOI</p>"
+      }
+     },
+     "06d45477c5904dc3b90dd470ed9d33f4": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_25162e64c98542958bbdcbac954fd16e"
+      }
+     },
+     "0811404a99694ea88690ff0748d086af": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_template_areas": "\"widget001 widget001 widget001 widget001 widget001 widget001 widget001 widget001 widget001 widget001\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget004 widget004 widget004\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget003 widget003 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007\"\n\"widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007\"\n\"widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007\"\n\"widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007\"",
+       "grid_template_columns": "repeat(10, 1fr)",
+       "grid_template_rows": "repeat(11, 1fr)",
+       "height": "1100px",
+       "width": "auto"
+      }
+     },
+     "0c4d558990c5430fb7b9a0c0ecb9fba4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_547ecfda4d154cefb57b02358269f567",
+       "style": "IPY_MODEL_7f4e1787c71f42b5afce699e484f220a"
+      }
+     },
+     "0ca9ca8460054e33baab5c83463bcb85": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletMapStyleModel",
+      "state": {
+       "_model_module_version": "^0.14.0"
+      }
+     },
+     "0eedb08bdd6f44b69fdf1d1aff3132ad": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "136a5c34608044b3829160b1e6180407": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1987caa33393459aa586e3fd3f9b8e5b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ec509fa685484b538c33c93782dd12ae",
+       "style": "IPY_MODEL_012ab6ad3ce7485a880980de064ef95a",
+       "value": "<b>Output CSV:</b>"
+      }
+     },
+     "1aeb7517fe4449f2a6775ee7d7d5a582": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TextModel",
+      "state": {
+       "layout": "IPY_MODEL_9b8311612bc44a9ca1bcb1a64de4c5d0",
+       "placeholder": "1M",
+       "style": "IPY_MODEL_480eb8f2e61541a38f57cca94eefc4a6",
+       "value": "1M"
+      }
+     },
+     "1e4f79fae01a440486bcdd0e680c0b40": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "227c12b89382410994b00b8fd9f54ed4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "248b97f7e7fa4aa9bfad0297830444a9": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.14.0",
+       "_view_module_version": "^0.14.0",
+       "attribution": "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> &copy; <a href=\"http://cartodb.com/attributions\">CartoDB</a>",
+       "base": true,
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "min_zoom": 1,
+       "name": "Countries and Locations",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "http://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
+      }
+     },
+     "24995bc64f794661b84547637ec8f441": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_area": "widget004",
+       "height": "100%",
+       "margin": "0px 10px 10px 0px",
+       "padding": "5px 5px 5px 5px",
+       "width": "100%"
+      }
+     },
+     "25162e64c98542958bbdcbac954fd16e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_area": "widget005",
+       "height": "100%",
+       "margin": "0px 10px 10px 0px",
+       "padding": "5px 5px 5px 5px",
+       "width": "100%"
+      }
+     },
+     "29333c1dcb384bb9b974a4dccc3f7fdb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_4aa6fe978f7f4edca717a1842aea06f5",
+        "IPY_MODEL_5ed81fb162864b68a1ec09223498581b",
+        "IPY_MODEL_2bb657508eb149d9b24819cd4d2f5be4",
+        "IPY_MODEL_fcf83f92e5e646129159297ce616cb70",
+        "IPY_MODEL_77b5d237e45b4b6bb6e6953ef68036bb",
+        "IPY_MODEL_9b5881e045144daeb23bd52e7d83a86f",
+        "IPY_MODEL_c3519df66e1743b0bfd1696304d290f8",
+        "IPY_MODEL_8b7b2a1c4ab5454fb7cc7b0d5a15eeae",
+        "IPY_MODEL_cf36fd9684574c85a9120e589aa711af",
+        "IPY_MODEL_1aeb7517fe4449f2a6775ee7d7d5a582",
+        "IPY_MODEL_1987caa33393459aa586e3fd3f9b8e5b",
+        "IPY_MODEL_c3617ac0f4584233a158c83f926861c0",
+        "IPY_MODEL_6863911b1c7b4b30940a640c7a7262a3",
+        "IPY_MODEL_493adbe81a794f0999329215ffb90c59"
+       ],
+       "layout": "IPY_MODEL_abdd79a70815490494539e7f96773ab0"
+      }
+     },
+     "2bb657508eb149d9b24819cd4d2f5be4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_bdb7175ebd5842d9860c0d6d982ac711",
+       "style": "IPY_MODEL_0eedb08bdd6f44b69fdf1d1aff3132ad",
+       "value": "<b>Start Date:</b>"
+      }
+     },
+     "360235c5feeb4e6eb525954bd90f331b": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_24995bc64f794661b84547637ec8f441"
+      }
+     },
+     "3624fd09f2144b7d90dc3699039f9e6b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_area": "widget006",
+       "height": "100%",
+       "margin": "0px 10px 10px 0px",
+       "padding": "5px 5px 5px 5px",
+       "width": "100%"
+      }
+     },
+     "3a410ddf306c4802b014021ecd5a363c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3bb9598eafcf4039ab5e248a445c6e59": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3bf865286fb94faca1a869a668b74cd7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4222f9ccd5cd41fab47d43b92675a84b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "85%"
+      }
+     },
+     "480eb8f2e61541a38f57cca94eefc4a6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "493adbe81a794f0999329215ffb90c59": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TextModel",
+      "state": {
+       "layout": "IPY_MODEL_4222f9ccd5cd41fab47d43b92675a84b",
+       "placeholder": "example_WIT.png",
+       "style": "IPY_MODEL_227c12b89382410994b00b8fd9f54ed4",
+       "value": "example_WIT.png"
+      }
+     },
+     "4aa6fe978f7f4edca717a1842aea06f5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6ac1dd8ff5c0460a96f5203da95b760a",
+       "style": "IPY_MODEL_3bf865286fb94faca1a869a668b74cd7",
+       "value": "<b>Map Overlay:</b>"
+      }
+     },
+     "4ace4a2538fb47d3ab5ed48091c16707": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "547ecfda4d154cefb57b02358269f567": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5ed81fb162864b68a1ec09223498581b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DropdownModel",
+      "state": {
+       "_options_labels": [
+        "None",
+        "ESRI World Imagery",
+        "Sentinel-2 Geomedian",
+        "Water Observations from Space"
+       ],
+       "index": 0,
+       "layout": "IPY_MODEL_ed9e3fc52f1e4a50beaa4d9f0d1fc735",
+       "style": "IPY_MODEL_3bb9598eafcf4039ab5e248a445c6e59"
+      }
+     },
+     "5f0fad5c1e0f4834821e52b19541b7ac": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_area": "widget003",
+       "height": "auto",
+       "width": "auto"
+      }
+     },
+     "601c77d0c4ff4dc7abd798d4f0294b49": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "button_style": "info",
+       "description": "Run",
+       "layout": "IPY_MODEL_5f0fad5c1e0f4834821e52b19541b7ac",
+       "style": "IPY_MODEL_a41dd4ef96934630872c7d6c2844a675"
+      }
+     },
+     "635ef9ec2cc74e88a79be2987798728a": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_9457a8b3ed5f4c628c2b8125af5e79e9"
+      }
+     },
+     "6419f445ddfa4d9baaa5baff106680a4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6863911b1c7b4b30940a640c7a7262a3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_fb2f3af334cd4ba89ebf8a14fb3ba670",
+       "style": "IPY_MODEL_bf084dd246914d4e9f7d898b3e267e1c",
+       "value": "<b>Output Plot:</b>"
+      }
+     },
+     "6ac1dd8ff5c0460a96f5203da95b760a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6f36ae22612b4e26a2829041bc00ab4a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "85%"
+      }
+     },
+     "70f44a7cbe984b129ac18dae5762b6ef": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "748d073230ab4b58a5af51628a7ca23d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "85%"
+      }
+     },
+     "77b218dd1f9248cd8d3426822b3e0d3c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_area": "widget001",
+       "height": "100%",
+       "margin": "0px 10px 10px 0px",
+       "padding": "5px 5px 5px 5px",
+       "width": "100%"
+      }
+     },
+     "77b5d237e45b4b6bb6e6953ef68036bb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6419f445ddfa4d9baaa5baff106680a4",
+       "style": "IPY_MODEL_7ab38b14d75a40b18000e9c2605c3cf7",
+       "value": "<b>End Date:</b>"
+      }
+     },
+     "7ab38b14d75a40b18000e9c2605c3cf7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7d25b1d9ddce401fa0e6016861fc380e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "85%"
+      }
+     },
+     "7ee0efb126ef413c8a267def74506859": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletMapModel",
+      "state": {
+       "_model_module_version": "^0.14.0",
+       "_view_module_version": "^0.14.0",
+       "bottom": 1294,
+       "center": [
+        4,
+        20
+       ],
+       "controls": [
+        "IPY_MODEL_f720948544d3423eaa37fae6429ca6c0",
+        "IPY_MODEL_d2e8b7b98aa2498cb06445496346bb1e",
+        "IPY_MODEL_b02994167778467481d4dbd699867996"
+       ],
+       "default_style": "IPY_MODEL_0ca9ca8460054e33baab5c83463bcb85",
+       "dragging_style": "IPY_MODEL_c887593434654448ac94b2323f73955b",
+       "east": 71.71875000000001,
+       "fullscreen": false,
+       "interpolation": "bilinear",
+       "layers": [
+        "IPY_MODEL_248b97f7e7fa4aa9bfad0297830444a9",
+        "IPY_MODEL_fd6d9cd878d84f75b19ba5afd98a3175"
+       ],
+       "layout": "IPY_MODEL_3624fd09f2144b7d90dc3699039f9e6b",
+       "left": 844,
+       "modisdate": "yesterday",
+       "north": 48.45835188280866,
+       "options": [
+        "bounce_at_zoom_limits",
+        "box_zoom",
+        "center",
+        "close_popup_on_click",
+        "double_click_zoom",
+        "dragging",
+        "fullscreen",
+        "inertia",
+        "inertia_deceleration",
+        "inertia_max_speed",
+        "interpolation",
+        "keyboard",
+        "keyboard_pan_offset",
+        "keyboard_zoom_offset",
+        "max_zoom",
+        "min_zoom",
+        "scroll_wheel_zoom",
+        "tap",
+        "tap_tolerance",
+        "touch_zoom",
+        "world_copy_jump",
+        "zoom",
+        "zoom_animation_threshold",
+        "zoom_delta",
+        "zoom_snap",
+        "zoom_start"
+       ],
+       "right": 1432,
+       "scroll_wheel_zoom": true,
+       "south": -42.811521745097885,
+       "style": "IPY_MODEL_9ddced346d3c4dc6971d3387744343de",
+       "top": 708,
+       "west": -31.640625000000004,
+       "window_url": "https://sandbox.digitalearth.africa/user/caitlinadams/lab/tree/dev/deafrica-sandbox-notebooks/Real_world_examples/Wetlands_insight_tool.ipynb",
+       "zoom": 3
+      }
+     },
+     "7f2ad0ef92b0416d8ab6507aaa06b5bf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a46a9583cf664b38bac5089e11dddb0a"
+       ],
+       "layout": "IPY_MODEL_dcd4c18d8f46407abda8617123407125"
+      }
+     },
+     "7f4e1787c71f42b5afce699e484f220a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8b7b2a1c4ab5454fb7cc7b0d5a15eeae": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "BoundedFloatTextModel",
+      "state": {
+       "layout": "IPY_MODEL_7d25b1d9ddce401fa0e6016861fc380e",
+       "max": 1,
+       "step": 0.05,
+       "style": "IPY_MODEL_fbd6da45b35745abb35f662f956708c1"
+      }
+     },
+     "9457a8b3ed5f4c628c2b8125af5e79e9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_area": "widget007",
+       "height": "100%",
+       "margin": "0px 10px 10px 0px",
+       "padding": "5px 5px 5px 5px",
+       "width": "100%"
+      }
+     },
+     "95a2405cec11451f9a68de5e4395061c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9b5881e045144daeb23bd52e7d83a86f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DatePickerModel",
+      "state": {
+       "disabled": false,
+       "layout": "IPY_MODEL_6f36ae22612b4e26a2829041bc00ab4a",
+       "style": "IPY_MODEL_4ace4a2538fb47d3ab5ed48091c16707"
+      }
+     },
+     "9b8311612bc44a9ca1bcb1a64de4c5d0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "85%"
+      }
+     },
+     "9c156f3d1f50468c83749587769e833a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9ddced346d3c4dc6971d3387744343de": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletMapStyleModel",
+      "state": {
+       "_model_module_version": "^0.14.0"
+      }
+     },
+     "a41dd4ef96934630872c7d6c2844a675": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "a46a9583cf664b38bac5089e11dddb0a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "GridBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_05183ed950e844bebe30287ddbe8cc77",
+        "IPY_MODEL_29333c1dcb384bb9b974a4dccc3f7fdb",
+        "IPY_MODEL_601c77d0c4ff4dc7abd798d4f0294b49",
+        "IPY_MODEL_360235c5feeb4e6eb525954bd90f331b",
+        "IPY_MODEL_06d45477c5904dc3b90dd470ed9d33f4",
+        "IPY_MODEL_7ee0efb126ef413c8a267def74506859",
+        "IPY_MODEL_635ef9ec2cc74e88a79be2987798728a"
+       ],
+       "layout": "IPY_MODEL_0811404a99694ea88690ff0748d086af"
+      }
+     },
+     "abdd79a70815490494539e7f96773ab0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_area": "widget002",
+       "height": "100%",
+       "margin": "0px 10px 10px 0px",
+       "padding": "5px 5px 5px 5px",
+       "width": "100%"
+      }
+     },
+     "b02994167778467481d4dbd699867996": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletDrawControlModel",
+      "state": {
+       "_model_module_version": "^0.14.0",
+       "_view_module_version": "^0.14.0",
+       "options": [
+        "position"
+       ],
+       "polygon": {
+        "allowIntersection": false,
+        "drawError": {
+         "color": "#FF6633",
+         "message": "Drawing error, clear all and try again"
+        },
+        "shapeOptions": {
+         "color": "#FFFFFF",
+         "fillColor": "#336699",
+         "fillOpacity": 0.4,
+         "opacity": 0.8
+        }
+       },
+       "polyline": {},
+       "rectangle": {
+        "shapeOptions": {
+         "color": "#FFFFFF",
+         "fillColor": "#336699",
+         "fillOpacity": 0.4,
+         "opacity": 0.8
+        }
+       }
+      }
+     },
+     "b50477ebdb7e4be1b64117c0e8aeb0db": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bdb7175ebd5842d9860c0d6d982ac711": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bf084dd246914d4e9f7d898b3e267e1c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c3519df66e1743b0bfd1696304d290f8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_3a410ddf306c4802b014021ecd5a363c",
+       "style": "IPY_MODEL_1e4f79fae01a440486bcdd0e680c0b40",
+       "value": "<b>Minimum Good Data:</b>"
+      }
+     },
+     "c3617ac0f4584233a158c83f926861c0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TextModel",
+      "state": {
+       "layout": "IPY_MODEL_748d073230ab4b58a5af51628a7ca23d",
+       "placeholder": "example_WIT.csv",
+       "style": "IPY_MODEL_95a2405cec11451f9a68de5e4395061c",
+       "value": "example_WIT.csv"
+      }
+     },
+     "c5d8cae6349641afa275bb69c1f55f7e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "85%"
+      }
+     },
+     "c887593434654448ac94b2323f73955b": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletMapStyleModel",
+      "state": {
+       "_model_module_version": "^0.14.0",
+       "cursor": "move"
+      }
+     },
+     "cc9ec68f70934c7986927411be9be1de": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cf36fd9684574c85a9120e589aa711af": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_136a5c34608044b3829160b1e6180407",
+       "style": "IPY_MODEL_eade6b708fe741a8b72a08f9b68ea088",
+       "value": "<b>Resampling Frequency:</b>"
+      }
+     },
+     "d2e8b7b98aa2498cb06445496346bb1e": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletAttributionControlModel",
+      "state": {
+       "_model_module_version": "^0.14.0",
+       "_view_module_version": "^0.14.0",
+       "options": [
+        "position",
+        "prefix"
+       ],
+       "position": "bottomright",
+       "prefix": "ipyleaflet"
+      }
+     },
+     "dcd4c18d8f46407abda8617123407125": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dfea9e89050d4ab0be0fa6228a081ad6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "eade6b708fe741a8b72a08f9b68ea088": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ec509fa685484b538c33c93782dd12ae": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ed9e3fc52f1e4a50beaa4d9f0d1fc735": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "85%"
+      }
+     },
+     "f720948544d3423eaa37fae6429ca6c0": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletZoomControlModel",
+      "state": {
+       "_model_module_version": "^0.14.0",
+       "_view_module_version": "^0.14.0",
+       "options": [
+        "position",
+        "zoom_in_text",
+        "zoom_in_title",
+        "zoom_out_text",
+        "zoom_out_title"
+       ]
+      }
+     },
+     "fb2f3af334cd4ba89ebf8a14fb3ba670": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fbd6da45b35745abb35f662f956708c1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fcf83f92e5e646129159297ce616cb70": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DatePickerModel",
+      "state": {
+       "disabled": false,
+       "layout": "IPY_MODEL_c5d8cae6349641afa275bb69c1f55f7e",
+       "style": "IPY_MODEL_9c156f3d1f50468c83749587769e833a"
+      }
+     },
+     "fd6d9cd878d84f75b19ba5afd98a3175": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletLayerGroupModel",
+      "state": {
+       "_model_module": "jupyter-leaflet",
+       "_model_module_version": "^0.14.0",
+       "_view_count": null,
+       "_view_module": "jupyter-leaflet",
+       "_view_module_version": "^0.14.0",
+       "base": false,
+       "bottom": false,
+       "name": "Map Overlays",
+       "options": [],
+       "popup": null,
+       "popup_max_height": null,
+       "popup_max_width": 300,
+       "popup_min_width": 50
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/Real_world_examples/Wetlands_insight_tool.ipynb
+++ b/Real_world_examples/Wetlands_insight_tool.ipynb
@@ -106,7 +106,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "70c24efc7a1e4a0b96bce7212e9b3580",
+       "model_id": "bdf5107b7118467d9edac302e2b412d4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -213,54 +213,7 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "012ab6ad3ce7485a880980de064ef95a": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "05183ed950e844bebe30287ddbe8cc77": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_77b218dd1f9248cd8d3426822b3e0d3c",
-       "style": "IPY_MODEL_cc9ec68f70934c7986927411be9be1de",
-       "value": "<h3>Wetlands Insight Tool</h3><p>Select parameters and AOI</p>"
-      }
-     },
-     "06d45477c5904dc3b90dd470ed9d33f4": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "layout": "IPY_MODEL_25162e64c98542958bbdcbac954fd16e"
-      }
-     },
-     "0811404a99694ea88690ff0748d086af": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "grid_template_areas": "\"widget001 widget001 widget001 widget001 widget001 widget001 widget001 widget001 widget001 widget001\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget004 widget004 widget004\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget003 widget003 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007\"\n\"widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007\"\n\"widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007\"\n\"widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007\"",
-       "grid_template_columns": "repeat(10, 1fr)",
-       "grid_template_rows": "repeat(11, 1fr)",
-       "height": "1100px",
-       "width": "auto"
-      }
-     },
-     "0c4d558990c5430fb7b9a0c0ecb9fba4": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_547ecfda4d154cefb57b02358269f567",
-       "style": "IPY_MODEL_7f4e1787c71f42b5afce699e484f220a"
-      }
-     },
-     "0ca9ca8460054e33baab5c83463bcb85": {
+     "00d10652001c45e9881d0db400ca6ac7": {
       "model_module": "jupyter-leaflet",
       "model_module_version": "^0.14.0",
       "model_name": "LeafletMapStyleModel",
@@ -268,393 +221,36 @@
        "_model_module_version": "^0.14.0"
       }
      },
-     "0eedb08bdd6f44b69fdf1d1aff3132ad": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "136a5c34608044b3829160b1e6180407": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "1987caa33393459aa586e3fd3f9b8e5b": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_ec509fa685484b538c33c93782dd12ae",
-       "style": "IPY_MODEL_012ab6ad3ce7485a880980de064ef95a",
-       "value": "<b>Output CSV:</b>"
-      }
-     },
-     "1aeb7517fe4449f2a6775ee7d7d5a582": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "TextModel",
-      "state": {
-       "layout": "IPY_MODEL_9b8311612bc44a9ca1bcb1a64de4c5d0",
-       "placeholder": "1M",
-       "style": "IPY_MODEL_480eb8f2e61541a38f57cca94eefc4a6",
-       "value": "1M"
-      }
-     },
-     "1e4f79fae01a440486bcdd0e680c0b40": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "227c12b89382410994b00b8fd9f54ed4": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "248b97f7e7fa4aa9bfad0297830444a9": {
-      "model_module": "jupyter-leaflet",
-      "model_module_version": "^0.14.0",
-      "model_name": "LeafletTileLayerModel",
-      "state": {
-       "_model_module_version": "^0.14.0",
-       "_view_module_version": "^0.14.0",
-       "attribution": "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> &copy; <a href=\"http://cartodb.com/attributions\">CartoDB</a>",
-       "base": true,
-       "max_native_zoom": 18,
-       "max_zoom": 20,
-       "min_native_zoom": 0,
-       "min_zoom": 1,
-       "name": "Countries and Locations",
-       "options": [
-        "attribution",
-        "detect_retina",
-        "max_native_zoom",
-        "max_zoom",
-        "min_native_zoom",
-        "min_zoom",
-        "no_wrap",
-        "tile_size",
-        "tms"
-       ],
-       "url": "http://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
-      }
-     },
-     "24995bc64f794661b84547637ec8f441": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "grid_area": "widget004",
-       "height": "100%",
-       "margin": "0px 10px 10px 0px",
-       "padding": "5px 5px 5px 5px",
-       "width": "100%"
-      }
-     },
-     "25162e64c98542958bbdcbac954fd16e": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "grid_area": "widget005",
-       "height": "100%",
-       "margin": "0px 10px 10px 0px",
-       "padding": "5px 5px 5px 5px",
-       "width": "100%"
-      }
-     },
-     "29333c1dcb384bb9b974a4dccc3f7fdb": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "VBoxModel",
-      "state": {
-       "children": [
-        "IPY_MODEL_4aa6fe978f7f4edca717a1842aea06f5",
-        "IPY_MODEL_5ed81fb162864b68a1ec09223498581b",
-        "IPY_MODEL_2bb657508eb149d9b24819cd4d2f5be4",
-        "IPY_MODEL_fcf83f92e5e646129159297ce616cb70",
-        "IPY_MODEL_77b5d237e45b4b6bb6e6953ef68036bb",
-        "IPY_MODEL_9b5881e045144daeb23bd52e7d83a86f",
-        "IPY_MODEL_c3519df66e1743b0bfd1696304d290f8",
-        "IPY_MODEL_8b7b2a1c4ab5454fb7cc7b0d5a15eeae",
-        "IPY_MODEL_cf36fd9684574c85a9120e589aa711af",
-        "IPY_MODEL_1aeb7517fe4449f2a6775ee7d7d5a582",
-        "IPY_MODEL_1987caa33393459aa586e3fd3f9b8e5b",
-        "IPY_MODEL_c3617ac0f4584233a158c83f926861c0",
-        "IPY_MODEL_6863911b1c7b4b30940a640c7a7262a3",
-        "IPY_MODEL_493adbe81a794f0999329215ffb90c59"
-       ],
-       "layout": "IPY_MODEL_abdd79a70815490494539e7f96773ab0"
-      }
-     },
-     "2bb657508eb149d9b24819cd4d2f5be4": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_bdb7175ebd5842d9860c0d6d982ac711",
-       "style": "IPY_MODEL_0eedb08bdd6f44b69fdf1d1aff3132ad",
-       "value": "<b>Start Date:</b>"
-      }
-     },
-     "360235c5feeb4e6eb525954bd90f331b": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "layout": "IPY_MODEL_24995bc64f794661b84547637ec8f441"
-      }
-     },
-     "3624fd09f2144b7d90dc3699039f9e6b": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "grid_area": "widget006",
-       "height": "100%",
-       "margin": "0px 10px 10px 0px",
-       "padding": "5px 5px 5px 5px",
-       "width": "100%"
-      }
-     },
-     "3a410ddf306c4802b014021ecd5a363c": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "3bb9598eafcf4039ab5e248a445c6e59": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "3bf865286fb94faca1a869a668b74cd7": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "4222f9ccd5cd41fab47d43b92675a84b": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "width": "85%"
-      }
-     },
-     "480eb8f2e61541a38f57cca94eefc4a6": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "493adbe81a794f0999329215ffb90c59": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "TextModel",
-      "state": {
-       "layout": "IPY_MODEL_4222f9ccd5cd41fab47d43b92675a84b",
-       "placeholder": "example_WIT.png",
-       "style": "IPY_MODEL_227c12b89382410994b00b8fd9f54ed4",
-       "value": "example_WIT.png"
-      }
-     },
-     "4aa6fe978f7f4edca717a1842aea06f5": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_6ac1dd8ff5c0460a96f5203da95b760a",
-       "style": "IPY_MODEL_3bf865286fb94faca1a869a668b74cd7",
-       "value": "<b>Map Overlay:</b>"
-      }
-     },
-     "4ace4a2538fb47d3ab5ed48091c16707": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "547ecfda4d154cefb57b02358269f567": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "5ed81fb162864b68a1ec09223498581b": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DropdownModel",
-      "state": {
-       "_options_labels": [
-        "None",
-        "ESRI World Imagery",
-        "Sentinel-2 Geomedian",
-        "Water Observations from Space"
-       ],
-       "index": 0,
-       "layout": "IPY_MODEL_ed9e3fc52f1e4a50beaa4d9f0d1fc735",
-       "style": "IPY_MODEL_3bb9598eafcf4039ab5e248a445c6e59"
-      }
-     },
-     "5f0fad5c1e0f4834821e52b19541b7ac": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "grid_area": "widget003",
-       "height": "auto",
-       "width": "auto"
-      }
-     },
-     "601c77d0c4ff4dc7abd798d4f0294b49": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ButtonModel",
-      "state": {
-       "button_style": "info",
-       "description": "Run",
-       "layout": "IPY_MODEL_5f0fad5c1e0f4834821e52b19541b7ac",
-       "style": "IPY_MODEL_a41dd4ef96934630872c7d6c2844a675"
-      }
-     },
-     "635ef9ec2cc74e88a79be2987798728a": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "layout": "IPY_MODEL_9457a8b3ed5f4c628c2b8125af5e79e9"
-      }
-     },
-     "6419f445ddfa4d9baaa5baff106680a4": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "6863911b1c7b4b30940a640c7a7262a3": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_fb2f3af334cd4ba89ebf8a14fb3ba670",
-       "style": "IPY_MODEL_bf084dd246914d4e9f7d898b3e267e1c",
-       "value": "<b>Output Plot:</b>"
-      }
-     },
-     "6ac1dd8ff5c0460a96f5203da95b760a": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "6f36ae22612b4e26a2829041bc00ab4a": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "width": "85%"
-      }
-     },
-     "70f44a7cbe984b129ac18dae5762b6ef": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "748d073230ab4b58a5af51628a7ca23d": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "width": "85%"
-      }
-     },
-     "77b218dd1f9248cd8d3426822b3e0d3c": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "grid_area": "widget001",
-       "height": "100%",
-       "margin": "0px 10px 10px 0px",
-       "padding": "5px 5px 5px 5px",
-       "width": "100%"
-      }
-     },
-     "77b5d237e45b4b6bb6e6953ef68036bb": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_6419f445ddfa4d9baaa5baff106680a4",
-       "style": "IPY_MODEL_7ab38b14d75a40b18000e9c2605c3cf7",
-       "value": "<b>End Date:</b>"
-      }
-     },
-     "7ab38b14d75a40b18000e9c2605c3cf7": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "7d25b1d9ddce401fa0e6016861fc380e": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "width": "85%"
-      }
-     },
-     "7ee0efb126ef413c8a267def74506859": {
+     "03459c546a794fa68df29ef0b19e23b3": {
       "model_module": "jupyter-leaflet",
       "model_module_version": "^0.14.0",
       "model_name": "LeafletMapModel",
       "state": {
        "_model_module_version": "^0.14.0",
        "_view_module_version": "^0.14.0",
-       "bottom": 1294,
+       "bottom": 2031,
        "center": [
-        4,
-        20
+        26.287822354121694,
+        12.420043945312502
        ],
        "controls": [
-        "IPY_MODEL_f720948544d3423eaa37fae6429ca6c0",
-        "IPY_MODEL_d2e8b7b98aa2498cb06445496346bb1e",
-        "IPY_MODEL_b02994167778467481d4dbd699867996"
+        "IPY_MODEL_e22d38602ac54efcba168c487979159c",
+        "IPY_MODEL_8e4842f911e5473eadb186ad45625bbe",
+        "IPY_MODEL_d7649aa6645744de9999d0faaf2c6c2d"
        ],
-       "default_style": "IPY_MODEL_0ca9ca8460054e33baab5c83463bcb85",
-       "dragging_style": "IPY_MODEL_c887593434654448ac94b2323f73955b",
-       "east": 71.71875000000001,
+       "default_style": "IPY_MODEL_6cf7daf2bb614101bda8eba63a10a0cb",
+       "dragging_style": "IPY_MODEL_61fe8b927fc442308dd65c6a6561627a",
+       "east": 32.78320312500001,
        "fullscreen": false,
        "interpolation": "bilinear",
        "layers": [
-        "IPY_MODEL_248b97f7e7fa4aa9bfad0297830444a9",
-        "IPY_MODEL_fd6d9cd878d84f75b19ba5afd98a3175"
+        "IPY_MODEL_44c3311b448b44f2938d70477bf60b85",
+        "IPY_MODEL_e7603046a57342fa88b519ab15cfbf21"
        ],
-       "layout": "IPY_MODEL_3624fd09f2144b7d90dc3699039f9e6b",
-       "left": 844,
+       "layout": "IPY_MODEL_7a7325d77cbe4ec29a91711b4904aa6b",
+       "left": 1958,
        "modisdate": "yesterday",
-       "north": 48.45835188280866,
+       "north": 46.73986059969267,
        "options": [
         "bounce_at_zoom_limits",
         "box_zoom",
@@ -683,28 +279,17 @@
         "zoom_snap",
         "zoom_start"
        ],
-       "right": 1432,
+       "right": 2421,
        "scroll_wheel_zoom": true,
-       "south": -42.811521745097885,
-       "style": "IPY_MODEL_9ddced346d3c4dc6971d3387744343de",
-       "top": 708,
-       "west": -31.640625000000004,
+       "south": 1.4939713066293239,
+       "style": "IPY_MODEL_6cf7daf2bb614101bda8eba63a10a0cb",
+       "top": 1445,
+       "west": -7.910156250000001,
        "window_url": "https://sandbox.digitalearth.africa/user/caitlinadams/lab/tree/dev/deafrica-sandbox-notebooks/Real_world_examples/Wetlands_insight_tool.ipynb",
-       "zoom": 3
+       "zoom": 4
       }
      },
-     "7f2ad0ef92b0416d8ab6507aaa06b5bf": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "children": [
-        "IPY_MODEL_a46a9583cf664b38bac5089e11dddb0a"
-       ],
-       "layout": "IPY_MODEL_dcd4c18d8f46407abda8617123407125"
-      }
-     },
-     "7f4e1787c71f42b5afce699e484f220a": {
+     "0720b5c659114de892d88b68647a54d4": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "DescriptionStyleModel",
@@ -712,18 +297,394 @@
        "description_width": ""
       }
      },
-     "8b7b2a1c4ab5454fb7cc7b0d5a15eeae": {
+     "102f834b5a4d4f92a24ca6c30ee16206": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "BoundedFloatTextModel",
+      "model_name": "DescriptionStyleModel",
       "state": {
-       "layout": "IPY_MODEL_7d25b1d9ddce401fa0e6016861fc380e",
-       "max": 1,
-       "step": 0.05,
-       "style": "IPY_MODEL_fbd6da45b35745abb35f662f956708c1"
+       "description_width": ""
       }
      },
-     "9457a8b3ed5f4c628c2b8125af5e79e9": {
+     "168cb3f7203441f399a2d0b66214bacd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1f57b65283cf4c52af99d1fa772b8e37": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "2024234bb0ef4b758d940d07a593666f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DatePickerModel",
+      "state": {
+       "disabled": false,
+       "layout": "IPY_MODEL_cfdf2c7460b14837af7a2865eb9c8d38",
+       "style": "IPY_MODEL_52185e7a174248eaa3b3c3439b57af1f"
+      }
+     },
+     "25574c2f5e124e6f98feca6fbd26c9ce": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "285c9a1579bf49869d18bcd9c12e17b4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_e81d048519f140b08f886894ed815279",
+        "IPY_MODEL_c07bfe61745647f7bd1125f27a0da807",
+        "IPY_MODEL_80ba54ed26c64de0a1c1a3de0fb0d977",
+        "IPY_MODEL_2024234bb0ef4b758d940d07a593666f",
+        "IPY_MODEL_f542ff808af2410bbf56b5ed34ba47ed",
+        "IPY_MODEL_62931dbbfb2f49e5b9247e5fd32ed2fe",
+        "IPY_MODEL_c1b85b729f214112886bcc8f83031613",
+        "IPY_MODEL_8a67ec0a41ff44e4a03acc4cce7c22fb",
+        "IPY_MODEL_479f407dbb8f465abf27907dfacea1c7",
+        "IPY_MODEL_64508b2ce174474cbeae0b4fa1241d09",
+        "IPY_MODEL_4f7a085fe3bd47b9833a064425a31a12",
+        "IPY_MODEL_51f24c502bbf41b5a23f814aaa1134aa",
+        "IPY_MODEL_7f63bfece4da4d8d975e5a3cc5ffbd85",
+        "IPY_MODEL_fabcea579e4d4105ad92ed9dfbc23ad3"
+       ],
+       "layout": "IPY_MODEL_e11ddb00324647baae275545d12dd290"
+      }
+     },
+     "2cbc2560431e4fde8b1e86c00ce722d5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2da0c31518fa43bd9d139ecaa87833de": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2f93e2de82ce47ffa07c7769891bdc6c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_template_areas": "\"widget001 widget001 widget001 widget001 widget001 widget001 widget001 widget001 widget001 widget001\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget004 widget004 widget004\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget002 widget002 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget003 widget003 widget006 widget006 widget006 widget006 widget006 widget005 widget005 widget005\"\n\"widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007\"\n\"widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007\"\n\"widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007\"\n\"widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007 widget007\"",
+       "grid_template_columns": "repeat(10, 1fr)",
+       "grid_template_rows": "repeat(11, 1fr)",
+       "height": "1100px",
+       "width": "auto"
+      }
+     },
+     "339fae9041c649d8af9481ea0f91fbbb": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.14.0",
+       "_view_module_version": "^0.14.0",
+       "attribution": "Digital Earth Africa",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "wofs_ls_summary_annual",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "time",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "time": "2020-01-01",
+       "transparent": true,
+       "url": "https://ows.digitalearth.africa/"
+      }
+     },
+     "39e57630199f46a39298725de69e71de": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_7f932a98fda642a1a3fb3877926bacfa"
+      }
+     },
+     "3ccb4c5a35de41cea7950dcdf2c25fef": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "85%"
+      }
+     },
+     "3d45ff3a77ed4c52a39477f123798c0c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_area": "widget003",
+       "height": "auto",
+       "width": "auto"
+      }
+     },
+     "44c3311b448b44f2938d70477bf60b85": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.14.0",
+       "_view_module_version": "^0.14.0",
+       "base": true,
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "min_zoom": 1,
+       "name": "Open Street Map",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ]
+      }
+     },
+     "46976327acbc476cb27f755c36ba6f4b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "479f407dbb8f465abf27907dfacea1c7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7966cd40ce1e49e594e9693565c9603a",
+       "style": "IPY_MODEL_b8dcdb042c344ff99f357a22fab32825",
+       "value": "<b>Resampling Frequency:</b>"
+      }
+     },
+     "4ae91842da2b44cb9fc01eef6da48b71": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "85%"
+      }
+     },
+     "4f7a085fe3bd47b9833a064425a31a12": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_168cb3f7203441f399a2d0b66214bacd",
+       "style": "IPY_MODEL_2cbc2560431e4fde8b1e86c00ce722d5",
+       "value": "<b>Output CSV:</b>"
+      }
+     },
+     "50ec9298dc7549b5b178ba97c0afd28f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_area": "widget001",
+       "height": "100%",
+       "margin": "0px 10px 10px 0px",
+       "padding": "5px 5px 5px 5px",
+       "width": "100%"
+      }
+     },
+     "51f24c502bbf41b5a23f814aaa1134aa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TextModel",
+      "state": {
+       "layout": "IPY_MODEL_3ccb4c5a35de41cea7950dcdf2c25fef",
+       "placeholder": "example_WIT.csv",
+       "style": "IPY_MODEL_a445fea7a4b24aad92db38ad3194a18c",
+       "value": "example_WIT.csv"
+      }
+     },
+     "52185e7a174248eaa3b3c3439b57af1f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "544d645897a04028bf77a839231b2073": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "85%"
+      }
+     },
+     "5e89a09b1dac4c509f1432a7eb74f201": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_area": "widget004",
+       "height": "100%",
+       "margin": "0px 10px 10px 0px",
+       "padding": "5px 5px 5px 5px",
+       "width": "100%"
+      }
+     },
+     "61c82abd4bb64d1cb18e7735b20f8d73": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "61fe8b927fc442308dd65c6a6561627a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletMapStyleModel",
+      "state": {
+       "_model_module_version": "^0.14.0",
+       "cursor": "move"
+      }
+     },
+     "62931dbbfb2f49e5b9247e5fd32ed2fe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DatePickerModel",
+      "state": {
+       "disabled": false,
+       "layout": "IPY_MODEL_bf5149912f3e4e6b83fb4c80c564dea9",
+       "style": "IPY_MODEL_e5115005508140da8eee7ee85765b013"
+      }
+     },
+     "64508b2ce174474cbeae0b4fa1241d09": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TextModel",
+      "state": {
+       "layout": "IPY_MODEL_4ae91842da2b44cb9fc01eef6da48b71",
+       "placeholder": "1M",
+       "style": "IPY_MODEL_9c0316b69712450ab1a897b9727bac16",
+       "value": "1M"
+      }
+     },
+     "6506caf2762745cb973fe35153968b30": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "65d18ee4f0ab418da45061cbaa27af0c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "button_style": "info",
+       "description": "Run",
+       "layout": "IPY_MODEL_3d45ff3a77ed4c52a39477f123798c0c",
+       "style": "IPY_MODEL_1f57b65283cf4c52af99d1fa772b8e37"
+      }
+     },
+     "6cf7daf2bb614101bda8eba63a10a0cb": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletMapStyleModel",
+      "state": {
+       "_model_module_version": "^0.14.0"
+      }
+     },
+     "6d11a3f02bac4f188279d347d84d663b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6e4a654f1fa44da88afa2c5491fd9b77": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.14.0",
+       "_view_module_version": "^0.14.0",
+       "attribution": "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "min_zoom": 1,
+       "name": "Esri.WorldImagery",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "7966cd40ce1e49e594e9693565c9603a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7a7325d77cbe4ec29a91711b4904aa6b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_area": "widget006",
+       "height": "100%",
+       "margin": "0px 10px 10px 0px",
+       "padding": "5px 5px 5px 5px",
+       "width": "100%"
+      }
+     },
+     "7f63bfece4da4d8d975e5a3cc5ffbd85": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_de23524a21204fd6a97445c583479537",
+       "style": "IPY_MODEL_61c82abd4bb64d1cb18e7735b20f8d73",
+       "value": "<b>Output Plot:</b>"
+      }
+     },
+     "7f932a98fda642a1a3fb3877926bacfa": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -735,7 +696,42 @@
        "width": "100%"
       }
      },
-     "95a2405cec11451f9a68de5e4395061c": {
+     "80ba54ed26c64de0a1c1a3de0fb0d977": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8b2a8f2434a24eecbdb16b92e97e0dc0",
+       "style": "IPY_MODEL_caea8447c7794ccc8765916c1948d5af",
+       "value": "<b>Start Date:</b>"
+      }
+     },
+     "819a0090fa5c41eea7b15d5e9f57789c": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_5e89a09b1dac4c509f1432a7eb74f201"
+      }
+     },
+     "8a67ec0a41ff44e4a03acc4cce7c22fb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "BoundedFloatTextModel",
+      "state": {
+       "layout": "IPY_MODEL_a261ee0665544e82bd0ff7e9363d05d6",
+       "max": 1,
+       "step": 0.05,
+       "style": "IPY_MODEL_bcd220bb735e4fabb4b431bf15d29d9c"
+      }
+     },
+     "8b2a8f2434a24eecbdb16b92e97e0dc0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8b9fa64e98434654aae2dd40671b93a3": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "DescriptionStyleModel",
@@ -743,17 +739,48 @@
        "description_width": ""
       }
      },
-     "9b5881e045144daeb23bd52e7d83a86f": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DatePickerModel",
+     "8e4842f911e5473eadb186ad45625bbe": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletAttributionControlModel",
       "state": {
-       "disabled": false,
-       "layout": "IPY_MODEL_6f36ae22612b4e26a2829041bc00ab4a",
-       "style": "IPY_MODEL_4ace4a2538fb47d3ab5ed48091c16707"
+       "_model_module_version": "^0.14.0",
+       "_view_module_version": "^0.14.0",
+       "options": [
+        "position",
+        "prefix"
+       ],
+       "position": "bottomright",
+       "prefix": "ipyleaflet"
       }
      },
-     "9b8311612bc44a9ca1bcb1a64de4c5d0": {
+     "9c0316b69712450ab1a897b9727bac16": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9dd5334e42fe4b9c929470589c32d23b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_50ec9298dc7549b5b178ba97c0afd28f",
+       "style": "IPY_MODEL_2da0c31518fa43bd9d139ecaa87833de",
+       "value": "<h3>Wetlands Insight Tool</h3><p>Select parameters and AOI</p>"
+      }
+     },
+     "9f49f94ab99a49d6af5d374fdc1e915a": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_b735957e3c2d44d6aae2effea2bb6c97"
+      }
+     },
+     "a261ee0665544e82bd0ff7e9363d05d6": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -761,7 +788,7 @@
        "width": "85%"
       }
      },
-     "9c156f3d1f50468c83749587769e833a": {
+     "a445fea7a4b24aad92db38ad3194a18c": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "DescriptionStyleModel",
@@ -769,50 +796,180 @@
        "description_width": ""
       }
      },
-     "9ddced346d3c4dc6971d3387744343de": {
-      "model_module": "jupyter-leaflet",
-      "model_module_version": "^0.14.0",
-      "model_name": "LeafletMapStyleModel",
-      "state": {
-       "_model_module_version": "^0.14.0"
-      }
-     },
-     "a41dd4ef96934630872c7d6c2844a675": {
+     "a61c020abb2e40909524328e3152b394": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "ButtonStyleModel",
-      "state": {}
-     },
-     "a46a9583cf664b38bac5089e11dddb0a": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "GridBoxModel",
+      "model_name": "HTMLModel",
       "state": {
-       "children": [
-        "IPY_MODEL_05183ed950e844bebe30287ddbe8cc77",
-        "IPY_MODEL_29333c1dcb384bb9b974a4dccc3f7fdb",
-        "IPY_MODEL_601c77d0c4ff4dc7abd798d4f0294b49",
-        "IPY_MODEL_360235c5feeb4e6eb525954bd90f331b",
-        "IPY_MODEL_06d45477c5904dc3b90dd470ed9d33f4",
-        "IPY_MODEL_7ee0efb126ef413c8a267def74506859",
-        "IPY_MODEL_635ef9ec2cc74e88a79be2987798728a"
-       ],
-       "layout": "IPY_MODEL_0811404a99694ea88690ff0748d086af"
+       "layout": "IPY_MODEL_6506caf2762745cb973fe35153968b30",
+       "style": "IPY_MODEL_fb620094c76542b998867a7b64eee0e7"
       }
      },
-     "abdd79a70815490494539e7f96773ab0": {
+     "b3d46c962aaa4bf1ad9a24b4b8680c4a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b735957e3c2d44d6aae2effea2bb6c97": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {
-       "grid_area": "widget002",
+       "grid_area": "widget005",
        "height": "100%",
        "margin": "0px 10px 10px 0px",
        "padding": "5px 5px 5px 5px",
        "width": "100%"
       }
      },
-     "b02994167778467481d4dbd699867996": {
+     "b8dcdb042c344ff99f357a22fab32825": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bcd220bb735e4fabb4b431bf15d29d9c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bdf5107b7118467d9edac302e2b412d4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_cc6b7a957bc14d9b8c6339fc7b72f00f"
+       ],
+       "layout": "IPY_MODEL_e2fe169b50de4a8cb2a5c8ac4fa4faf4"
+      }
+     },
+     "bf5149912f3e4e6b83fb4c80c564dea9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "85%"
+      }
+     },
+     "c07bfe61745647f7bd1125f27a0da807": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DropdownModel",
+      "state": {
+       "_options_labels": [
+        "None",
+        "ESRI World Imagery",
+        "Sentinel-2 Geomedian",
+        "Water Observations from Space"
+       ],
+       "index": 3,
+       "layout": "IPY_MODEL_f9330abb949944b6b91521b405a759d4",
+       "style": "IPY_MODEL_0720b5c659114de892d88b68647a54d4"
+      }
+     },
+     "c1b85b729f214112886bcc8f83031613": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c8e8149cfca540e99fee1a1a60058d4c",
+       "style": "IPY_MODEL_b3d46c962aaa4bf1ad9a24b4b8680c4a",
+       "value": "<b>Minimum Good Data:</b>"
+      }
+     },
+     "c8e8149cfca540e99fee1a1a60058d4c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "caea8447c7794ccc8765916c1948d5af": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cb01746187534d089391d3a15364487e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cc6b7a957bc14d9b8c6339fc7b72f00f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "GridBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_9dd5334e42fe4b9c929470589c32d23b",
+        "IPY_MODEL_285c9a1579bf49869d18bcd9c12e17b4",
+        "IPY_MODEL_65d18ee4f0ab418da45061cbaa27af0c",
+        "IPY_MODEL_819a0090fa5c41eea7b15d5e9f57789c",
+        "IPY_MODEL_9f49f94ab99a49d6af5d374fdc1e915a",
+        "IPY_MODEL_03459c546a794fa68df29ef0b19e23b3",
+        "IPY_MODEL_39e57630199f46a39298725de69e71de"
+       ],
+       "layout": "IPY_MODEL_2f93e2de82ce47ffa07c7769891bdc6c"
+      }
+     },
+     "cfdf2c7460b14837af7a2865eb9c8d38": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "85%"
+      }
+     },
+     "d438efe9f7954622a24e0a7d0b3e87ac": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.14.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.14.0",
+       "_view_module_version": "^0.14.0",
+       "attribution": "Digital Earth Africa",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "gm_s2_annual",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "time",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "time": "2020-01-01",
+       "transparent": true,
+       "url": "https://ows.digitalearth.africa/"
+      }
+     },
+     "d7649aa6645744de9999d0faaf2c6c2d": {
       "model_module": "jupyter-leaflet",
       "model_module_version": "^0.14.0",
       "model_name": "LeafletDrawControlModel",
@@ -846,132 +1003,25 @@
        }
       }
      },
-     "b50477ebdb7e4be1b64117c0e8aeb0db": {
+     "de23524a21204fd6a97445c583479537": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "bdb7175ebd5842d9860c0d6d982ac711": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "bf084dd246914d4e9f7d898b3e267e1c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "c3519df66e1743b0bfd1696304d290f8": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_3a410ddf306c4802b014021ecd5a363c",
-       "style": "IPY_MODEL_1e4f79fae01a440486bcdd0e680c0b40",
-       "value": "<b>Minimum Good Data:</b>"
-      }
-     },
-     "c3617ac0f4584233a158c83f926861c0": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "TextModel",
-      "state": {
-       "layout": "IPY_MODEL_748d073230ab4b58a5af51628a7ca23d",
-       "placeholder": "example_WIT.csv",
-       "style": "IPY_MODEL_95a2405cec11451f9a68de5e4395061c",
-       "value": "example_WIT.csv"
-      }
-     },
-     "c5d8cae6349641afa275bb69c1f55f7e": {
+     "e11ddb00324647baae275545d12dd290": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {
-       "width": "85%"
+       "grid_area": "widget002",
+       "height": "100%",
+       "margin": "0px 10px 10px 0px",
+       "padding": "5px 5px 5px 5px",
+       "width": "100%"
       }
      },
-     "c887593434654448ac94b2323f73955b": {
-      "model_module": "jupyter-leaflet",
-      "model_module_version": "^0.14.0",
-      "model_name": "LeafletMapStyleModel",
-      "state": {
-       "_model_module_version": "^0.14.0",
-       "cursor": "move"
-      }
-     },
-     "cc9ec68f70934c7986927411be9be1de": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "cf36fd9684574c85a9120e589aa711af": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_136a5c34608044b3829160b1e6180407",
-       "style": "IPY_MODEL_eade6b708fe741a8b72a08f9b68ea088",
-       "value": "<b>Resampling Frequency:</b>"
-      }
-     },
-     "d2e8b7b98aa2498cb06445496346bb1e": {
-      "model_module": "jupyter-leaflet",
-      "model_module_version": "^0.14.0",
-      "model_name": "LeafletAttributionControlModel",
-      "state": {
-       "_model_module_version": "^0.14.0",
-       "_view_module_version": "^0.14.0",
-       "options": [
-        "position",
-        "prefix"
-       ],
-       "position": "bottomright",
-       "prefix": "ipyleaflet"
-      }
-     },
-     "dcd4c18d8f46407abda8617123407125": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "dfea9e89050d4ab0be0fa6228a081ad6": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "eade6b708fe741a8b72a08f9b68ea088": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "ec509fa685484b538c33c93782dd12ae": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "ed9e3fc52f1e4a50beaa4d9f0d1fc735": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "width": "85%"
-      }
-     },
-     "f720948544d3423eaa37fae6429ca6c0": {
+     "e22d38602ac54efcba168c487979159c": {
       "model_module": "jupyter-leaflet",
       "model_module_version": "^0.14.0",
       "model_name": "LeafletZoomControlModel",
@@ -987,13 +1037,13 @@
        ]
       }
      },
-     "fb2f3af334cd4ba89ebf8a14fb3ba670": {
+     "e2fe169b50de4a8cb2a5c8ac4fa4faf4": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "fbd6da45b35745abb35f662f956708c1": {
+     "e5115005508140da8eee7ee85765b013": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "DescriptionStyleModel",
@@ -1001,17 +1051,7 @@
        "description_width": ""
       }
      },
-     "fcf83f92e5e646129159297ce616cb70": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DatePickerModel",
-      "state": {
-       "disabled": false,
-       "layout": "IPY_MODEL_c5d8cae6349641afa275bb69c1f55f7e",
-       "style": "IPY_MODEL_9c156f3d1f50468c83749587769e833a"
-      }
-     },
-     "fd6d9cd878d84f75b19ba5afd98a3175": {
+     "e7603046a57342fa88b519ab15cfbf21": {
       "model_module": "jupyter-leaflet",
       "model_module_version": "^0.14.0",
       "model_name": "LeafletLayerGroupModel",
@@ -1023,12 +1063,76 @@
        "_view_module_version": "^0.14.0",
        "base": false,
        "bottom": false,
+       "layers": [
+        "IPY_MODEL_339fae9041c649d8af9481ea0f91fbbb"
+       ],
        "name": "Map Overlays",
        "options": [],
        "popup": null,
        "popup_max_height": null,
        "popup_max_width": 300,
        "popup_min_width": 50
+      }
+     },
+     "e81d048519f140b08f886894ed815279": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6d11a3f02bac4f188279d347d84d663b",
+       "style": "IPY_MODEL_102f834b5a4d4f92a24ca6c30ee16206",
+       "value": "<b>Map Overlay:</b>"
+      }
+     },
+     "e8bdb038d85441b0ad31eb670e4e409c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f542ff808af2410bbf56b5ed34ba47ed": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_46976327acbc476cb27f755c36ba6f4b",
+       "style": "IPY_MODEL_e8bdb038d85441b0ad31eb670e4e409c",
+       "value": "<b>End Date:</b>"
+      }
+     },
+     "f9330abb949944b6b91521b405a759d4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "85%"
+      }
+     },
+     "fabad1e4bc0f4a028a86ac482ecc7a4b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fabcea579e4d4105ad92ed9dfbc23ad3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TextModel",
+      "state": {
+       "layout": "IPY_MODEL_544d645897a04028bf77a839231b2073",
+       "placeholder": "example_WIT.png",
+       "style": "IPY_MODEL_8b9fa64e98434654aae2dd40671b93a3",
+       "value": "example_WIT.png"
+      }
+     },
+     "fb620094c76542b998867a7b64eee0e7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
       }
      }
     },

--- a/Tools/deafrica_tools/app/wetlandsinsighttool.py
+++ b/Tools/deafrica_tools/app/wetlandsinsighttool.py
@@ -166,12 +166,6 @@ class wit_app(HBox):
         # Create map widget
         self.m = deawidgets.create_map()
         
-#         # Add wms layers
-#         for i, product in enumerate(self.product_list):
-#             layer = deawidgets.create_dea_wms_layer(product[1], self.product_year)
-#             layer.name = product[0]
-#             self.m.add_layer(layer)
-        
         self.m.layout = make_box_layout()
         
         # Add tools to map widget

--- a/Tools/deafrica_tools/app/wetlandsinsighttool.py
+++ b/Tools/deafrica_tools/app/wetlandsinsighttool.py
@@ -38,6 +38,7 @@ from ipyleaflet import (
     DrawControl,
     WidgetControl,
     LayerGroup,
+    LayersControl,
 )
 from traitlets import Unicode
 from ipywidgets import (
@@ -94,8 +95,10 @@ class wit_app(HBox):
         self.out_plot = "example_WIT.png"
         self.product_list = [
             ("None", "none"),
+            ("ESRI World Imagery", "esri_world_imagery"),
             ("Sentinel-2 Geomedian", "gm_s2_annual"),
             ("Water Observations from Space", "wofs_ls_summary_annual"),
+            
         ]
         self.product = self.product_list[0][1]
         self.product_year = "2020-01-01"
@@ -158,9 +161,17 @@ class wit_app(HBox):
         
         # Begin by displaying an empty layer group, and update the group with desired WMS on interaction.
         self.deafrica_layers = LayerGroup(layers=())
+        self.deafrica_layers.name = 'Map Overlays'
 
         # Create map widget
         self.m = deawidgets.create_map()
+        
+#         # Add wms layers
+#         for i, product in enumerate(self.product_list):
+#             layer = deawidgets.create_dea_wms_layer(product[1], self.product_year)
+#             layer.name = product[0]
+#             self.m.add_layer(layer)
+        
         self.m.layout = make_box_layout()
         
         # Add tools to map widget
@@ -188,7 +199,7 @@ class wit_app(HBox):
         
         parameter_selection = VBox(
             [
-                HTML("<b>DE Africa Overlay:</b>"),
+                HTML("<b>Map Overlay:</b>"),
                 deaoverlay_dropdown,
                 HTML("<b>Start Date:</b>"),
                 startdate_picker,
@@ -278,6 +289,10 @@ class wit_app(HBox):
 
         if self.product == "none":
             self.deafrica_layers.clear_layers()
+        elif self.product == "esri_world_imagery":
+            self.deafrica_layers.clear_layers()
+            layer = basemap_to_tiles(basemaps.Esri.WorldImagery)
+            self.deafrica_layers.add_layer(layer)
         else:
             self.deafrica_layers.clear_layers()
             layer = deawidgets.create_dea_wms_layer(self.product, self.product_year)

--- a/Tools/deafrica_tools/app/widgetconstructors.py
+++ b/Tools/deafrica_tools/app/widgetconstructors.py
@@ -225,11 +225,10 @@ def create_map(map_center=(4, 20), zoom_level=3):
     
 #     esri_worldimagery = leaflet.basemap_to_tiles(leaflet.basemaps.Esri.WorldImagery)
 #     esri_worldimagery.name = 'ESRI World Imagery'
+    osm = leaflet.basemap_to_tiles(leaflet.basemaps.OpenStreetMap.Mapnik)
+    osm.name = 'Countries and Locations'
 
-    cartodb_positron = leaflet.basemap_to_tiles(leaflet.basemaps.CartoDB.Positron)
-    cartodb_positron.name = 'Countries and Locations'
-
-    m = leaflet.Map(center=map_center, zoom=zoom_level, basemap=cartodb_positron, scroll_wheel_zoom=True)
+    m = leaflet.Map(center=map_center, zoom=zoom_level, basemap=osm, scroll_wheel_zoom=True)
 #     m.add_layer(esri_worldimagery)
     
 #     control = LayersControl(position='topright')

--- a/Tools/deafrica_tools/app/widgetconstructors.py
+++ b/Tools/deafrica_tools/app/widgetconstructors.py
@@ -33,6 +33,7 @@ Last modified: Oct 2021
 """
 
 import ipyleaflet as leaflet
+from ipyleaflet import LayersControl
 import ipywidgets as widgets
 from traitlets import Unicode
 
@@ -197,7 +198,7 @@ def create_html(value):
     return html
 
 
-def create_map(map_center=(4, 20), zoom_level=3, basemap=leaflet.basemaps.Esri.WorldImagery):
+def create_map(map_center=(4, 20), zoom_level=3):
     '''
     Create an interactive ipyleaflet map
     
@@ -222,9 +223,17 @@ def create_map(map_center=(4, 20), zoom_level=3, basemap=leaflet.basemaps.Esri.W
         
     '''
     
-    tiled_basemap = leaflet.basemap_to_tiles(basemap)
+#     esri_worldimagery = leaflet.basemap_to_tiles(leaflet.basemaps.Esri.WorldImagery)
+#     esri_worldimagery.name = 'ESRI World Imagery'
+
+    cartodb_positron = leaflet.basemap_to_tiles(leaflet.basemaps.CartoDB.Positron)
+    cartodb_positron.name = 'Countries and Locations'
+
+    m = leaflet.Map(center=map_center, zoom=zoom_level, basemap=cartodb_positron, scroll_wheel_zoom=True)
+#     m.add_layer(esri_worldimagery)
     
-    m = leaflet.Map(center=map_center, zoom=zoom_level, basemap=tiled_basemap)
+#     control = LayersControl(position='topright')
+#     m.add_control(control)
     
     return m
 

--- a/Tools/deafrica_tools/app/widgetconstructors.py
+++ b/Tools/deafrica_tools/app/widgetconstructors.py
@@ -198,7 +198,7 @@ def create_html(value):
     return html
 
 
-def create_map(map_center=(4, 20), zoom_level=3):
+def create_map(map_center=(4, 20), zoom_level=3, basemap=leaflet.basemaps.OpenStreetMap.Mapnik, basemap_name='Open Street Map'):
     '''
     Create an interactive ipyleaflet map
     
@@ -214,7 +214,9 @@ def create_map(map_center=(4, 20), zoom_level=3):
         Defaults to 3 to view all of Africa
     basemap : ipyleaflet basemap (dict)
         Basemap to use, can be any from https://ipyleaflet.readthedocs.io/en/latest/api_reference/basemaps.html
-        Defaults to ESRI World Imagery (basemaps.Esri.WorldImagery)
+        Defaults to Open Street Map (basemaps.OpenStreetMap.Mapnik)
+    basemap_name : string
+        Layer name for the basemap
         
     Returns
     -------
@@ -223,16 +225,10 @@ def create_map(map_center=(4, 20), zoom_level=3):
         
     '''
     
-#     esri_worldimagery = leaflet.basemap_to_tiles(leaflet.basemaps.Esri.WorldImagery)
-#     esri_worldimagery.name = 'ESRI World Imagery'
-    osm = leaflet.basemap_to_tiles(leaflet.basemaps.OpenStreetMap.Mapnik)
-    osm.name = 'Countries and Locations'
+    basemap_tiles = leaflet.basemap_to_tiles(basemap)
+    basemap_tiles.name = basemap_name
 
-    m = leaflet.Map(center=map_center, zoom=zoom_level, basemap=osm, scroll_wheel_zoom=True)
-#     m.add_layer(esri_worldimagery)
-    
-#     control = LayersControl(position='topright')
-#     m.add_control(control)
+    m = leaflet.Map(center=map_center, zoom=zoom_level, basemap=basemap_tiles, scroll_wheel_zoom=True)
     
     return m
 


### PR DESCRIPTION
### Proposed changes
- Change basemap in app to CartoDB Positron
- Add ESRI basemap as overlay option
- Turn on zoom with mouse on map

### Checklist (replace `[ ]` with `[x]` to check off)
- [x] Remove any unused Python packages from `Load packages`
- [x] Remove any unused/empty code cells
- [x] Remove any guidance cells (e.g. `General advice`)
- [x] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [x] Include relevant tags in the final notebook cell and re-use tags if possible
- [x] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
