### PR TITLE
update mangroves analysis to use indexed GMW

### DIFF
--- a/Tools/deafrica_tools/datahandling.py
+++ b/Tools/deafrica_tools/datahandling.py
@@ -40,7 +40,6 @@ import pytz
 from collections import Counter
 from datacube.utils import masking
 from scipy.ndimage import binary_dilation
-from datacube.storage.masking import mask_invalid_data
 from odc.algo import mask_cleanup
 from copy import deepcopy
 import odc.algo


### PR DESCRIPTION
Also snuck into the PR the removal of an import in the `deafrica-tools.datahandling` script that was causing a warning