### PR TITLE
Added geomedian widget to Tools and Datasets.

### DIFF
--- a/Datasets/GeoMAD.ipynb
+++ b/Datasets/GeoMAD.ipynb
@@ -72,6 +72,7 @@
     "    * Geomedian surface reflectance example\n",
     "    * Median Absolute Deviations example\n",
     "3. A simple example anlaysis using GeoMAD \n",
+    "4. An interactive widget for understanding the geomedian statistic\n",
     "\n",
     "***"
    ]
@@ -102,7 +103,8 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from deafrica_tools.plotting import rgb"
+    "from deafrica_tools.plotting import rgb\n",
+    "from deafrica_tools.app import geomedian"
    ]
   },
   {
@@ -171,7 +173,15 @@
        "      <td>Surface Reflectance Annual Geometric Median an...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>gm_ls5_ls7_annual_lowres</th>\n",
+       "      <td>Surface Reflectance Annual Geometric Median an...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>gm_ls8_annual</th>\n",
+       "      <td>Surface Reflectance Annual Geometric Median an...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gm_ls8_annual_lowres</th>\n",
        "      <td>Surface Reflectance Annual Geometric Median an...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -186,18 +196,30 @@
        "      <th>gm_s2_semiannual</th>\n",
        "      <td>Surface Reflectance Semiannual Geometric Media...</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gm_s2_semiannual_lowres</th>\n",
+       "      <td>Surface Reflectance Semiannual Geometric Media...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gmw</th>\n",
+       "      <td>Global Mangrove Watch data sourced from the UN...</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                                           description\n",
-       "name                                                                  \n",
-       "gm_ls5_ls7_annual    Surface Reflectance Annual Geometric Median an...\n",
-       "gm_ls8_annual        Surface Reflectance Annual Geometric Median an...\n",
-       "gm_s2_annual         Surface Reflectance Annual Geometric Median an...\n",
-       "gm_s2_annual_lowres  Annual Geometric Median, Sentinel-2 - Low Reso...\n",
-       "gm_s2_semiannual     Surface Reflectance Semiannual Geometric Media..."
+       "                                                                description\n",
+       "name                                                                       \n",
+       "gm_ls5_ls7_annual         Surface Reflectance Annual Geometric Median an...\n",
+       "gm_ls5_ls7_annual_lowres  Surface Reflectance Annual Geometric Median an...\n",
+       "gm_ls8_annual             Surface Reflectance Annual Geometric Median an...\n",
+       "gm_ls8_annual_lowres      Surface Reflectance Annual Geometric Median an...\n",
+       "gm_s2_annual              Surface Reflectance Annual Geometric Median an...\n",
+       "gm_s2_annual_lowres       Annual Geometric Median, Sentinel-2 - Low Reso...\n",
+       "gm_s2_semiannual          Surface Reflectance Semiannual Geometric Media...\n",
+       "gm_s2_semiannual_lowres   Surface Reflectance Semiannual Geometric Media...\n",
+       "gmw                       Global Mangrove Watch data sourced from the UN..."
       ]
      },
      "execution_count": 3,
@@ -779,7 +801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -799,7 +821,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -836,7 +858,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -884,7 +906,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -917,7 +939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -969,7 +991,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -1001,6 +1023,63 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Interactive widget: Understanding the geomedian"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this interactive widget example, you have a dataset of Earth observation satellite data. It contains the red, green, and blue bands, which are the bands generally used to generate colour images. The widget focuses on a single pixel that has data for 3 different timesteps. We can composite (combine) these 3 timesteps into one using a statistical composition method such as `median` or `geomedian`.\n",
+    "\n",
+    "This widget shows that the median does **not** always account for very large or very small band values, and may not be particularly representative of the variation we see in the three timesteps. \n",
+    "\n",
+    "Variation is better incorporated into the `Geomedian RGB - All timesteps` result, as the geomedian formula treats each timestep as a multi-dimensional vector. We see this results in differing values between the median and geomedian."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b0ad114876e54cd2903af5710ab1f3c8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(VBox(children=(HBox(children=(Output(), VBox(children=(IntSlider(value=58, description='Red', m…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "geomedian.run_app()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, try:\n",
+    "\n",
+    ">Timestep 1: (0,0,0)\n",
+    "\n",
+    ">Timestep 2: (0, 255, 0)\n",
+    "\n",
+    ">Timestep 3: (255, 255, 255)\n",
+    "\n",
+    "The geomedian shows a more representative value that incorporates some of the variation across the timesteps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "***\n",
     "\n",
     "## Additional information\n",
@@ -1016,7 +1095,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1040,16 +1119,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'2021-10-21'"
+       "'2021-12-22'"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/Tools/deafrica_tools/app/geomedian.py
+++ b/Tools/deafrica_tools/app/geomedian.py
@@ -1,0 +1,126 @@
+"""
+Geomedian widget: generates an interactive visualisation of
+the geomedian summary statistic. 
+"""
+
+# Load modules 
+import ipywidgets as widgets
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+import numpy as np
+import xarray as xr
+from odc.algo import xr_geomedian
+
+def run_app():
+    
+    """
+    An interactive app that allows users to visualise the difference between the median and geomedian time-series summary statistics. By modifying the red-green-blue values of three timesteps for a given pixel, the user changes the output summary statistics. 
+    
+    This allows a visual representation of the difference through the output values, RGB colour, as well as showing values plotted as a vector on a 3-dimensional  space.
+    
+    Last modified: December 2021
+    """
+    
+    # Define the red-green-blue sliders for timestep 1
+    p1r = widgets.IntSlider(description='Red', max=255, value=58)
+    p1g = widgets.IntSlider(description='Green', max=255, value=153)
+    p1b = widgets.IntSlider(description='Blue', max=255, value=68)
+
+    # Define the red-green-blue sliders for timestep 2
+    p2r = widgets.IntSlider(description='Red', max=255, value=208)
+    p2g = widgets.IntSlider(description='Green', max=255, value=221)
+    p2b = widgets.IntSlider(description='Blue', max=255, value=203)
+
+    # Define the red-green-blue sliders for timestep 3
+    p3r = widgets.IntSlider(description='Red', max=255, value=202)
+    p3g = widgets.IntSlider(description='Green', max=255, value=82)
+    p3b = widgets.IntSlider(description='Blue', max=255, value=33)
+
+    # Define the median calculation for the timesteps
+    def f(p1r, p1g, p1b, p2r, p2g, p2b, p3r, p3g, p3b):
+        print('Red Median = {}'.format(np.median([p1r, p2r, p3r])))
+        print('Green Median = {}'.format(np.median([p1g, p2g, p3g])))
+        print('Blue Median = {}'.format(np.median([p1b, p2b, p3b])))
+
+    # Define the geomedian calculation for the timesteps
+    def g(p1r, p1g, p1b, p2r, p2g, p2b, p3r, p3g, p3b):
+        print('Red Geomedian = {:.2f}'.format(xr_geomedian(xr.Dataset({"red": (("x", "y", "time"), [[[np.float32(p1r), np.float32(p2r), np.float32(p3r)]]]), "green": (("x", "y", "time"), [[[np.float32(p1g), np.float32(p2g), np.float32(p3g)]]]),  "blue": (("x", "y", "time"), [[[np.float32(p1b), np.float32(p2b), np.float32(p3b)]]])})).red.values.ravel()[0]))    
+        print('Green Geomedian = {:.2f}'.format(xr_geomedian(xr.Dataset({"red": (("x", "y", "time"), [[[np.float32(p1r), np.float32(p2r), np.float32(p3r)]]]), "green": (("x", "y", "time"), [[[np.float32(p1g), np.float32(p2g), np.float32(p3g)]]]),  "blue": (("x", "y", "time"), [[[np.float32(p1b), np.float32(p2b), np.float32(p3b)]]])})).green.values.ravel()[0]))    
+        print('Blue Geomedian = {:.2f}'.format(xr_geomedian(xr.Dataset({"red": (("x", "y", "time"), [[[np.float32(p1r), np.float32(p2r), np.float32(p3r)]]]), "green": (("x", "y", "time"), [[[np.float32(p1g), np.float32(p2g), np.float32(p3g)]]]),  "blue": (("x", "y", "time"), [[[np.float32(p1b), np.float32(p2b), np.float32(p3b)]]])})).blue.values.ravel()[0]))    
+
+    # Define the Timestep 1 box colour
+    def h(p1r, p1g, p1b):
+        fig1, axes1 = plt.subplots(figsize=(2,2))
+        fig1 = plt.imshow([[(p1r, p1g, p1b)]])
+        axes1.set_title('Timestep 1')
+        axes1.axis('off')
+        plt.show(fig1)
+
+    # Define the Timestep 2 box colour
+    def hh(p2r, p2g, p2b):    
+        fig2, axes2 = plt.subplots(figsize=(2,2))
+        fig2 = plt.imshow([[(p2r, p2g, p2b)]])
+        axes2.set_title('Timestep 2')
+        axes2.axis('off')
+        plt.show(fig2)
+
+    # Define the Timestep 3 box colour
+    def hhh(p3r, p3g, p3b):    
+        fig3, axes3 = plt.subplots(figsize=(2,2))
+        fig3 = plt.imshow([[(p3r, p3g, p3b)]])
+        axes3.set_title('Timestep 3')
+        axes3.axis('off')
+        plt.show(fig3)
+
+    # Define the Median RGB colour box
+    def i(p1r, p1g, p1b, p2r, p2g, p2b, p3r, p3g, p3b):
+        fig4, axes4 = plt.subplots(figsize=(3,3))
+        fig4 = plt.imshow([[(int(np.median([p1r, p2r, p3r])), int(np.median([p1g, p2g, p3g])), int(np.median([p1b, p2b, p3b])))]])
+        axes4.set_title('Median RGB - All timesteps')
+        axes4.axis('off')
+        plt.show(fig4)
+
+    # Define the Geomedian RGB colour box
+    def ii(p1r, p1g, p1b, p2r, p2g, p2b, p3r, p3g, p3b):
+        fig5, axes5 = plt.subplots(figsize=(3,3))
+        fig5 = plt.imshow([[(int(xr_geomedian(xr.Dataset({"red": (("x", "y", "time"), [[[np.float32(p1r), np.float32(p2r), np.float32(p3r)]]]), "green": (("x", "y", "time"), [[[np.float32(p1g), np.float32(p2g), np.float32(p3g)]]]),  "blue": (("x", "y", "time"), [[[np.float32(p1b), np.float32(p2b), np.float32(p3b)]]])})).red.values.ravel()[0]), int(xr_geomedian(xr.Dataset({"red": (("x", "y", "time"), [[[np.float32(p1r), np.float32(p2r), np.float32(p3r)]]]), "green": (("x", "y", "time"), [[[np.float32(p1g), np.float32(p2g), np.float32(p3g)]]]),  "blue": (("x", "y", "time"), [[[np.float32(p1b), np.float32(p2b), np.float32(p3b)]]])})).green.values.ravel()[0]), int(xr_geomedian(xr.Dataset({"red": (("x", "y", "time"), [[[np.float32(p1r), np.float32(p2r), np.float32(p3r)]]]), "green": (("x", "y", "time"), [[[np.float32(p1g), np.float32(p2g), np.float32(p3g)]]]),  "blue": (("x", "y", "time"), [[[np.float32(p1b), np.float32(p2b), np.float32(p3b)]]])})).blue.values.ravel()[0]))]])
+        axes5.set_title('Geomedian RGB - All timesteps')
+        axes5.axis('off')
+        plt.show(fig5)
+
+    # Define 3-D axis to display vectors on 
+    def j(p1r, p1g, p1b, p2r, p2g, p2b, p3r, p3g, p3b):
+        fig6 = plt.figure()
+        axes6 = fig6.add_subplot(111, projection='3d')
+        x = [p1r, p2r, p3r, int(np.median([p1r, p2r, p3r])), int(xr_geomedian(xr.Dataset({"red": (("x", "y", "time"), [[[np.float32(p1r), np.float32(p2r), np.float32(p3r)]]]), "green": (("x", "y", "time"), [[[np.float32(p1g), np.float32(p2g), np.float32(p3g)]]]),  "blue": (("x", "y", "time"), [[[np.float32(p1b), np.float32(p2b), np.float32(p3b)]]])})).red.values.ravel()[0])]
+        y = [p1g, p2g, p3g, int(np.median([p1g, p2g, p3g])), int(xr_geomedian(xr.Dataset({"red": (("x", "y", "time"), [[[np.float32(p1r), np.float32(p2r), np.float32(p3r)]]]), "green": (("x", "y", "time"), [[[np.float32(p1g), np.float32(p2g), np.float32(p3g)]]]),  "blue": (("x", "y", "time"), [[[np.float32(p1b), np.float32(p2b), np.float32(p3b)]]])})).green.values.ravel()[0])]
+        z = [p1b, p2b, p3b, int(np.median([p1b, p2b, p3b])), int(xr_geomedian(xr.Dataset({"red": (("x", "y", "time"), [[[np.float32(p1r), np.float32(p2r), np.float32(p3r)]]]), "green": (("x", "y", "time"), [[[np.float32(p1g), np.float32(p2g), np.float32(p3g)]]]),  "blue": (("x", "y", "time"), [[[np.float32(p1b), np.float32(p2b), np.float32(p3b)]]])})).blue.values.ravel()[0])]
+        labels = [' 1', ' 2', ' 3', ' median', ' geomedian']
+        axes6.scatter(x, y, z, c=['black','black','black','r', 'blue'], marker='o')
+        axes6.set_xlabel('Red')
+        axes6.set_ylabel('Green')
+        axes6.set_zlabel('Blue')
+        axes6.set_xlim3d(0, 255)
+        axes6.set_ylim3d(0, 255)
+        axes6.set_zlim3d(0, 255)
+        for ax, ay, az, label in zip(x, y, z, labels):
+            axes6.text(ax, ay, az, label)
+        plt.title('Each band represents a dimension.')
+        plt.show()
+
+    # Define outputs
+    outf = widgets.interactive_output(f, {'p1r': p1r, 'p2r': p2r,'p3r': p3r, 'p1g': p1g, 'p2g': p2g,'p3g': p3g, 'p1b': p1b, 'p2b': p2b,'p3b': p3b})
+    outg = widgets.interactive_output(g, {'p1r': p1r, 'p2r': p2r,'p3r': p3r, 'p1g': p1g, 'p2g': p2g,'p3g': p3g, 'p1b': p1b, 'p2b': p2b,'p3b': p3b})
+
+    outh = widgets.interactive_output(h, {'p1r': p1r, 'p1g': p1g, 'p1b': p1b})
+    outhh = widgets.interactive_output(hh, {'p2r': p2r, 'p2g': p2g, 'p2b': p2b})
+    outhhh = widgets.interactive_output(hhh, {'p3r': p3r, 'p3g': p3g, 'p3b': p3b})
+
+    outi = widgets.interactive_output(i, {'p1r': p1r, 'p2r': p2r,'p3r': p3r, 'p1g': p1g, 'p2g': p2g,'p3g': p3g, 'p1b': p1b, 'p2b': p2b,'p3b': p3b})
+    outii = widgets.interactive_output(ii, {'p1r': p1r, 'p2r': p2r,'p3r': p3r, 'p1g': p1g, 'p2g': p2g,'p3g': p3g, 'p1b': p1b, 'p2b': p2b,'p3b': p3b})
+
+    outj = widgets.interactive_output(j, {'p1r': p1r, 'p2r': p2r,'p3r': p3r, 'p1g': p1g, 'p2g': p2g,'p3g': p3g, 'p1b': p1b, 'p2b': p2b,'p3b': p3b})
+
+    app_output = widgets.HBox([widgets.VBox([widgets.HBox([outh, widgets.VBox([ p1r, p1g, p1b])]), widgets.HBox([outhh, widgets.VBox([p2r, p2g, p2b])]), widgets.HBox([outhhh, widgets.VBox([ p3r, p3g, p3b])])]), widgets.VBox([widgets.HBox([widgets.VBox([outf, outi]), widgets.VBox([outg, outii])]), outj])])
+    
+    return app_output

--- a/Tools/setup.py
+++ b/Tools/setup.py
@@ -71,7 +71,7 @@ except FileNotFoundError:
     
 setup_kwargs = {
     'name': NAME,
-    'version': '0.1.1',
+    'version': '0.1.2',
     'description': DESCRIPTION,
     'long_description': long_description,
     'author': AUTHOR,


### PR DESCRIPTION
### Proposed changes
Geomedian widget migrated from defunct training website to the Datasets notebook. Interactive app added to the Tools package.

### Checklist (replace `[ ]` with `[x]` to check off)
- [x] Remove any unused Python packages from `Load packages`
- [x] Remove any unused/empty code cells
- [x] Remove any guidance cells (e.g. `General advice`)
- [x] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended)
- [x] Include relevant tags in the first notebook cell and re-use tags if possible
- [x] Ensure appropriate colour schemes  have been used to maximise accessibility for vision impairment. Test your images or learn more with [Coblis](https://www.color-blindness.com/coblis-color-blindness-simulator/) or [TPGI](https://www.tpgi.com/color-contrast-checker/)
- [x] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
