### PR TITLE
ls9 load_ard and pq bug

### DIFF
--- a/Tools/deafrica_tools/datahandling.py
+++ b/Tools/deafrica_tools/datahandling.py
@@ -111,9 +111,11 @@ def load_ard(
         * ls5_sr ('sr' denotes surface reflectance)
         * ls7_sr
         * ls8_sr
+        * ls9_sr
         * ls5_st ('st' denotes surface temperature)
         * ls7_st
         * ls8_st
+        * ls9_st
 
     Sentinel-2:
         * s2_l2a
@@ -131,7 +133,7 @@ def load_ard(
     products : list
         A list of product names to load data from. For example:
 
-        * Landsat C2: ``['ls5_sr', 'ls7_sr', 'ls8_sr']``
+        * Landsat C2: ``['ls5_sr', 'ls7_sr', 'ls8_sr', 'ls9_sr']``
         * Sentinel-2: ``['s2_l2a']``
         * Sentinel-1: ``['s1_rtc']``
 
@@ -246,8 +248,8 @@ def load_ard(
     if not products:
         raise ValueError(
             "Please provide a list of product names to load data from. "
-            "Valid options are: Landsat C2 SR: ['ls5_sr', 'ls7_sr', 'ls8_sr'], or "
-            "Landsat C2 ST: ['ls5_st', 'ls7_st', 'ls8_st'], or "
+            "Valid options are: Landsat C2 SR: ['ls5_sr', 'ls7_sr', 'ls8_sr', 'ls9_sr'], or "
+            "Landsat C2 ST: ['ls5_st', 'ls7_st', 'ls8_st', 'ls9_st'], or "
             "Sentinel-2: ['s2_l2a'], or"
             "Sentinel-1: ['s1_rtc'], or"
         )
@@ -454,15 +456,17 @@ def load_ard(
         mask, _ = masking.create_mask_value(
             ds[fmask_band].attrs["flags_definition"], **categories_to_mask_ls
         )
+        
         pq_mask = (ds[fmask_band] & mask) != 0
         
-        # identify pixels that will become negative after rescaling (but not 0 values)
-        invalid = (
-                 ((ds[data_bands] < (-1.0 * -0.2 / 0.0000275)) & (ds[data_bands] > 0))
-                .to_array(dim="band")
-                .any(dim="band")
-            )
-        
+        # only run if data bands are present 
+        if measurements != ["pixel_quality"]: 
+            # identify pixels that will become negative after rescaling (but not 0 values)
+            invalid = (
+                    ((ds[data_bands] < (-1.0 * -0.2 / 0.0000275)) & (ds[data_bands] > 0))
+                    .to_array(dim="band")
+                    .any(dim="band")
+                    )
         #merge masks
         pq_mask = xr.ufuncs.logical_or(pq_mask, pq_mask)
 

--- a/Tools/deafrica_tools/datahandling.py
+++ b/Tools/deafrica_tools/datahandling.py
@@ -100,7 +100,7 @@ def load_ard(
     Loads analysis ready data.
 
     Loads and combines Landsat USGS Collections 2, Sentinel-2, and Sentinel-1 for
-    multiple sensors (i.e. ls5t, ls7e and ls8c for Landsat; s2a and s2b for Sentinel-2),
+    multiple sensors (i.e. ls5t, ls7e, ls8c and ls9 for Landsat; s2a and s2b for Sentinel-2),
     optionally applies pixel quality masks, and drops time steps that
     contain greater than a minimum proportion of good quality (e.g. non-
     cloudy or shadowed) pixels.
@@ -123,7 +123,7 @@ def load_ard(
     Sentinel-1:
         * s1_rtc
 
-    Last modified: August 2021
+    Last modified: Feb 2021
 
     Parameters
     ----------
@@ -392,7 +392,7 @@ def load_ard(
 
         if product_type == "ls":
             # handle LS seperately to S2/S1 due to collection_category
-            #force the user to load Tier 1
+            # force the user to load Tier 1
             datasets = dc.find_datasets(
                 product=product, collection_category='T1', **query
             )
@@ -421,7 +421,8 @@ def load_ard(
         )
 
     # If predicate is specified, use this function to filter the list
-    # of datasets prior to load
+    # of datasets prior to load (this now redundant as dc.load now supports
+    # a predicate filter)
     if predicate:
         if verbose:
             print(f"Filtering datasets using filter function")
@@ -460,13 +461,15 @@ def load_ard(
         pq_mask = (ds[fmask_band] & mask) != 0
         
         # only run if data bands are present 
-        if measurements != ["pixel_quality"]: 
-            # identify pixels that will become negative after rescaling (but not 0 values)
+        if len(data_bands) > 0: 
+            
+        # identify pixels that will become negative after rescaling (but not 0 values)
             invalid = (
                     ((ds[data_bands] < (-1.0 * -0.2 / 0.0000275)) & (ds[data_bands] > 0))
                     .to_array(dim="band")
                     .any(dim="band")
                     )
+
         #merge masks
         pq_mask = xr.ufuncs.logical_or(pq_mask, pq_mask)
 


### PR DESCRIPTION
### Proposed changes
Update load_ard to include ls9 and remove bug when only loading pq band

### Checklist (replace `[ ]` with `[x]` to check off)
- [X] Remove any unused Python packages from `Load packages`
- [X] Remove any unused/empty code cells
- [X] Remove any guidance cells (e.g. `General advice`)
- [X] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended)
- [X] Include relevant tags in the first notebook cell and re-use tags if possible
- [X] Ensure appropriate colour schemes  have been used to maximise accessibility for vision impairment. Test your images or learn more with [Coblis](https://www.color-blindness.com/coblis-color-blindness-simulator/) or [TPGI](https://www.tpgi.com/color-contrast-checker/)
- [X] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated

### Closes issues (optional)
- Closes Issue #348 
- Closes Issue #339 
