### PR TITLE
update the bandinces for EVI

### DIFF
--- a/Tools/deafrica_tools/bandindices.py
+++ b/Tools/deafrica_tools/bandindices.py
@@ -141,7 +141,7 @@ def calculate_indices(
         "NDVI": lambda ds: (ds.nir - ds.red) / (ds.nir + ds.red),
         # Enhanced Vegetation Index, Huete 2002
         "EVI": lambda ds: (
-            (2.5 * (ds.nir - ds.red)) / (ds.nir + 6 * ds.red - 7.5 * ds.blue + 1)
+            2.5 * ((ds.nir - ds.red) / (ds.nir + 6 * ds.red - 7.5 * ds.blue + 1))
         ),
         # Leaf Area Index, Boegh 2002
         "LAI": lambda ds: (


### PR DESCRIPTION
### Proposed changes
The formula read as
(2.5 * (ds.nir - ds.red)) / (ds.nir + 6 * ds.red - 7.5 * ds. Blue + 1) in the calculate index function.
But the correct formula should be 2.5 * ((ds.nir - ds. Red) / (ds.nir + 6 * ds.red - 7.5 * ds. Blue + 1))

#448

### Checklist (replace `[ ]` with `[x]` to check off)
- [ X] Remove any unused Python packages from `Load packages`
- [ X] Remove any unused/empty code cells
- [ X] Remove any guidance cells (e.g. `General advice`)
- [ X] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended)
- [ X] Include relevant tags in the first notebook cell and re-use tags if possible
- [ X] Ensure appropriate colour schemes  have been used to maximise accessibility for vision impairment. Test your images or learn more with [Coblis](https://www.color-blindness.com/coblis-color-blindness-simulator/) or [TPGI](https://www.tpgi.com/color-contrast-checker/)
- [ X] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated

### Closes issues (optional)
- Closes Issue #000
