### PR TITLE
Fix deafrica_tools docs and add version for pip install

### DIFF
--- a/Tools/README.md
+++ b/Tools/README.md
@@ -6,17 +6,18 @@ Python functions and algorithms developed to assist in analysing Digital Earth A
 
 ## Installation
 
-This module is automatically installed on the Digital Earth Africa Sandbox. If for some reason the module isn't available on the Digital Earth Africa Sandbox, you can also `pip install` the module from the terminal.
+This module is automatically installed on the Digital Earth Africa Sandbox. If for some reason the module isn't available on the Digital Earth Africa Sandbox, or to upgrade the tools, you can `pip install` the module from the terminal.
 
-You can install the `deafrica-tools` package from PyPI using:
+You can install the latest version of `deafrica-tools` from PyPI using:
 
 ```
 python -m pip install --extra-index-url="https://packages.dea.ga.gov.au" deafrica-tools 
 ```
-or install the package from the `Tools` directory:
+
+or install the package directly from the `Tools` directory to incorperate local changes:
 
 ```
-python -m pip install --extra-index-url="https://packages.dea.ga.gov.au" -e Tools/
+python -m pip install --extra-index-url="https://packages.dea.ga.gov.au" Tools/
 ```
        
 To install this module from the source on any other system with `pip`:

--- a/Tools/deafrica_tools/__init__.py
+++ b/Tools/deafrica_tools/__init__.py
@@ -1,5 +1,6 @@
 __locales__ = __path__[0] + '/locales'
 
+__version__ = '2.3.7'
 
 def set_lang(lang=None):
     if lang is None:

--- a/Tools/pyproject.toml
+++ b/Tools/pyproject.toml
@@ -7,6 +7,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "deafrica-tools"
 version = "2.3.7"
+# reflect version changes in deafrica_tools/__init__.py
 
 description = "Functions and algorithms for analysing Digital Earth Africa data."
 authors = [{name = "Digital Earth Africa", email = "systems@digitalearthafrica.org"}]


### PR DESCRIPTION
### Proposed changes
Changes correct the installation docs to ensure the latest version of deafrica-tools is installed on the sandbox with pip. Correct version tagging has also been added to the project. 

### Checklist (replace `[ ]` with `[x]` to check off)
- [x] Remove any unused Python packages from `Load packages`
- [x] Remove any unused/empty code cells
- [x] Remove any guidance cells (e.g. `General advice`)
- [x] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended)
- [x] Include relevant tags in the first notebook cell and re-use tags if possible
- [x] Ensure appropriate colour schemes  have been used to maximise accessibility for vision impairment. Test your images or learn more with [Coblis](https://www.color-blindness.com/coblis-color-blindness-simulator/) or [TPGI](https://www.tpgi.com/color-contrast-checker/)
- [x] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated

### Closes issues (optional)
- Closes Issue #000
