### PR TITLE
load_ard changes

### DIFF
--- a/Tools/deafrica_tools/datahandling.py
+++ b/Tools/deafrica_tools/datahandling.py
@@ -125,6 +125,7 @@ def load_ard(
 
     Sentinel-2:
         * s2_l2a
+        * s2_l2a_c1
 
     Sentinel-1:
         * s1_rtc
@@ -140,7 +141,7 @@ def load_ard(
         A list of product names to load data from. For example:
 
         * Landsat C2: ``['ls5_sr', 'ls7_sr', 'ls8_sr', 'ls9_sr']``
-        * Sentinel-2: ``['s2_l2a']``
+        * Sentinel-2: ``['s2_l2a', 's2_l2a_c1']``
         * Sentinel-1: ``['s1_rtc']``
 
     min_gooddata : float, optional
@@ -256,7 +257,7 @@ def load_ard(
             "Please provide a list of product names to load data from. "
             "Valid options are: Landsat C2 SR: ['ls5_sr', 'ls7_sr', 'ls8_sr', 'ls9_sr'], or "
             "Landsat C2 ST: ['ls5_st', 'ls7_st', 'ls8_st', 'ls9_st'], or "
-            "Sentinel-2: ['s2_l2a'], or"
+            "Sentinel-2: ['s2_l2a', 's2_l2a_c1'], or"
             "Sentinel-1: ['s1_rtc'], or"
         )
     
@@ -611,6 +612,28 @@ def load_ard(
             if band == "surface_temperature":
                 ds[band] = ds[band] * 0.00341802 + 149.0
 
+        # add back attrs that are lost during scaling calcs
+        for band in ds.data_vars:
+            ds[band].attrs.update(attrs)
+    
+    if product == "s2_l2a_c1":
+        if verbose:
+            print("Re-scaling Sentinel-2 C1 data")
+
+        sr_bands = ["coastal", "red", "green", "blue", "rededge1", "rededge2", 
+                    "rededge3", "nir", "nir08", "nir09", "swir16", "swir22"]
+        
+        if mask_pixel_quality == False:
+            # set nodata to NaNs before rescaling
+            # in the case where masking hasn't already done this
+            for band in ds.data_vars:
+                if band not in qa:
+                    ds[band] = odc.algo.to_f32(ds[band])
+
+        for band in ds.data_vars:
+            if band in sr_bands:
+                ds[band] = ds[band] - 1000
+        
         # add back attrs that are lost during scaling calcs
         for band in ds.data_vars:
             ds[band].attrs.update(attrs)


### PR DESCRIPTION
### Proposed changes
Changes to `load_ard()` to accommodate Sentinel-2 C1. Only works in dev while C1 is available there.

### Checklist (replace `[ ]` with `[x]` to check off)
- [X] Remove any unused Python packages from `Load packages`
- [X] Remove any unused/empty code cells
- [X] Remove any guidance cells (e.g. `General advice`)
- [X] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended)
- [X] Include relevant tags in the first notebook cell and re-use tags if possible
- [X] Ensure appropriate colour schemes  have been used to maximise accessibility for vision impairment. Test your images or learn more with [Coblis](https://www.color-blindness.com/coblis-color-blindness-simulator/) or [TPGI](https://www.tpgi.com/color-contrast-checker/)
- [X] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated

